### PR TITLE
Separate python wheel

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Install module
         run: |
           pip install num_dual --no-index --find-links dist --force-reinstall

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Install module
         run: |
           pip install num_dual --no-index --find-links dist --force-reinstall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -60,11 +60,11 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: x86_64
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --universal2 --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --universal2 --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -92,7 +92,7 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -135,7 +135,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Install module
         run: |
           pip install num_dual --no-index --find-links dist --force-reinstall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -60,11 +60,11 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: x86_64
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Build wheels - universal2
         uses: messense/maturin-action@v1
         with:
-          args: --release --universal2 --out dist --no-sdist
+          args: --release --universal2 --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -92,7 +92,7 @@ jobs:
         uses: messense/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -135,7 +135,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Install module
         run: |
           pip install num_dual --no-index --find-links dist --force-reinstall

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -41,11 +41,11 @@ jobs:
         uses: messense/maturin-action@main
         with:
           target: x86_64
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Build wheels - universal2
         uses: messense/maturin-action@main
         with:
-          args: --release --universal2 --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --universal2 --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: messense/maturin-action@main
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
+          args: --release --out dist --no-sdist -m build_wheel/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           manylinux: auto
           command: build
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -41,11 +41,11 @@ jobs:
         uses: messense/maturin-action@main
         with:
           target: x86_64
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Build wheels - universal2
         uses: messense/maturin-action@main
         with:
-          args: --release --universal2 --out dist --no-sdist
+          args: --release --universal2 --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: messense/maturin-action@main
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --no-sdist
+          args: --release --out dist --no-sdist -m build_wheels/Cargo.toml
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,11 @@ keywords = ["mathematics", "numerics", "differentiation"]
 categories = ["data-structures", "science", "mathematics"]
 exclude = ["/.github/*", "*.ipynb", "./docs/*"]
 
-[lib]
-name = "num_dual"
-crate-type = ["cdylib", "lib"]
-
 [dependencies]
 num-traits = "0.2"
 ndarray = { version = "0.15", optional = true }
 ndarray-linalg = { version = "0.14", optional = true }
-pyo3 = { version = "0.14", optional = true, features = ["extension-module", "abi3", "abi3-py36", "multiple-pymethods"] }
+pyo3 = { version = "0.15", optional = true }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "num-dual"
 version = "0.3.0"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
-           "Philipp Rehner <rehner@itt.uni-stuttgart.de>"]
+           "Philipp Rehner <prehner@ethz.ch>"]
 edition = "2018"
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/build_wheel/Cargo.toml
+++ b/build_wheel/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "num_dual"
+version = "0.3.0"
+authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
+           "Philipp Rehner <prehner@ethz.ch>"]
+edition = "2018"
+readme = "../README.md"
+license = "MIT OR Apache-2.0"
+description = "Generalized (hyper) dual numbers for the calculation of exact (partial) derivatives"
+homepage = "https://github.com/itt-ustutt/num-dual"
+repository = "https://github.com/itt-ustutt/num-dual"
+keywords = ["mathematics", "numerics", "differentiation"]
+categories = ["data-structures", "science", "mathematics"]
+exclude = ["/.github/*", "*.ipynb", "./docs/*"]
+
+[lib]
+name = "num_dual"
+crate-type = ["cdylib"]
+
+[dependencies]
+num-dual = { path = "..", features = ["python"]}
+pyo3 = { version = "0.15", features = ["extension-module", "abi3", "abi3-py36", "multiple-pymethods"] }

--- a/build_wheel/src/lib.rs
+++ b/build_wheel/src/lib.rs
@@ -1,0 +1,8 @@
+use num_dual as num_dual_rs;
+use pyo3::prelude::*;
+
+/// Implementation of SI numbers.
+#[pymodule]
+pub fn num_dual(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    num_dual_rs::python::num_dual(_py, m)
+}

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -17,8 +17,7 @@ pub use dual2::{PyDual2Dual64, PyDual2_64};
 pub use dual3::{PyDual3Dual64, PyDual3_64};
 pub use hyperdual::{PyHyperDual64, PyHyperDualDual64};
 
-#[pymodule]
-fn num_dual(_py: Python, m: &PyModule) -> PyResult<()> {
+pub fn num_dual(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<PyDual64>()?;
     m.add_class::<PyHyperDual64>()?;


### PR DESCRIPTION
Use a separate directory `build_wheel` where the python extension module is build.
This change is needed since it is currently not possible to use a crate that produces both a `rlib` and a `cdylib` on macos.