### PR TITLE
Expose python types of vector dual numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Publicly exposed all Python classes that are being generated. [#47](https://github.com/itt-ustutt/num-dual/pull/47)
+- Exported the `impl_dual_num` macro that implements the arithmetic operators for dual numbers in Python. [#47](https://github.com/itt-ustutt/num-dual/pull/47)
 
 ## [0.5.3] - 2022-11-11
 ### Added

--- a/src/dual2.rs
+++ b/src/dual2.rs
@@ -57,16 +57,24 @@ impl<T: Copy + Zero + AddAssign, F, const N: usize> Dual2Vec<T, F, N> {
 impl<T: One, F> Dual2<T, F> {
     /// Derive a scalar second order dual number
     /// ```
-    /// # use num_dual::{Dual2Vec64, DualNum, StaticVec};
-    /// let xy = StaticVec::new_vec([5.0, 3.0]).map(Dual2Vec64::<2>::from).derive();
-    /// let z = xy[0] * xy[1].powi(2);
-    /// assert_eq!(z.re, 45.0);            // xy²
-    /// assert_eq!(z.v1[0], 9.0);          // y²
-    /// assert_eq!(z.v1[1], 30.0);         // 2xy
-    /// assert_eq!(z.v2[(0,0)], 0.0);      // 0
-    /// assert_eq!(z.v2[(0,1)], 6.0);      // 2y
-    /// assert_eq!(z.v2[(1,0)], 6.0);      // 2y
-    /// assert_eq!(z.v2[(1,1)], 10.0);     // 2x
+    /// # use num_dual::{Dual2, DualNum};
+    /// let x = Dual2::from_re(5.0).derive().powi(2);
+    /// assert_eq!(x.re, 25.0);            // x²
+    /// assert_eq!(x.v1[0], 10.0);         // 2x
+    /// assert_eq!(x.v2[(0,0)], 2.0);      // 2
+    /// ```
+    ///
+    /// The argument can also be a dual number
+    /// ```
+    /// # use num_dual::{Dual64, Dual2, DualNum};
+    /// let x = Dual2::from_re(Dual64::from_re(5.0).derive())
+    ///     .derive()
+    ///     .powi(2);
+    /// assert_eq!(x.re.re(), 25.0);      // x²
+    /// assert_eq!(x.re.eps[0], 10.0);    // 2x
+    /// assert_eq!(x.v1[0].re, 10.0);     // 2x
+    /// assert_eq!(x.v1[0].eps[0], 2.0);  // 2
+    /// assert_eq!(x.v2[(0,0)].re, 2.0);  // 2
     /// ```
     #[inline]
     pub fn derive(mut self) -> Self {

--- a/src/python/dual2.rs
+++ b/src/python/dual2.rs
@@ -5,7 +5,35 @@ use pyo3::prelude::*;
 
 #[pyclass(name = "Dual2_64")]
 #[derive(Clone)]
-/// Hyper dual number using 64-bit-floats.
+/// Second order dual number using 64-bit-floats as fields.
+///
+/// A second order dual number consists of
+/// f_0 + f_1 ε_1 + f_2 ε_1^2
+/// where f_0 is the function value, f_1 the first derivative
+/// and f_2 the second derivative.
+///
+/// Examples
+///
+/// >>> from num_dual import Dual2_64 as D264
+/// >>> x = D264(1.0, 0.0, 0.0)
+/// >>> y = D264.from_re(2.0)
+/// >>> x + y
+/// 3 + [0]ε1 + [0]ε1²
+///
+/// First and second derivative of a function.
+///
+/// >>> from num_dual import Dual2_64 as D264, derive1
+/// >>> import numpy as np
+/// >>> x = derive2(4.0)
+/// >>> # this is equivalent to the above
+/// >>> x = D264(4.0, 1.0, 0.0)
+/// >>> fx = x*x + np.sqrt(x)
+/// >>> fx.value
+/// 18.0
+/// >>> fx.first_derivative
+/// 8.25
+/// >>> fx.second_derivative
+/// 1.96875
 pub struct PyDual2_64(Dual2_64);
 
 #[pymethods]
@@ -32,7 +60,7 @@ impl_dual_num!(PyDual2_64, Dual2_64, f64);
 
 #[pyclass(name = "Dual2Dual64")]
 #[derive(Clone)]
-/// Hyper dual number using 64-bit-floats.
+/// Second order dual number using dual numbers as fields.
 pub struct PyDual2Dual64(Dual2<Dual64, f64>);
 
 #[pymethods]
@@ -56,3 +84,30 @@ impl PyDual2Dual64 {
 }
 
 impl_dual_num!(PyDual2Dual64, Dual2<Dual64, f64>, PyDual64);
+
+macro_rules! impl_dual2_n {
+    ($py_type_name:ident, $n:literal) => {
+        #[pyclass(name = "Dual2Vec64")]
+        #[derive(Clone, Copy)]
+        pub struct $py_type_name(Dual2Vec64<$n>);
+
+        #[pymethods]
+        impl $py_type_name {
+            #[getter]
+            /// Gradient.
+            pub fn get_first_derivative(&self) -> [f64; $n] {
+                *self.0.v1.raw_array()
+            }
+
+            #[getter]
+            /// Hessian.
+            pub fn get_second_derivative(&self) -> Vec<Vec<f64>> {
+                self.0.v2.raw_data().iter().map(|a| a.to_vec()).collect()
+            }
+        }
+
+        impl_dual_num!($py_type_name, Dual2Vec64<$n>, f64);
+    };
+}
+
+pub(crate) use impl_dual2_n;

--- a/src/python/dual3.rs
+++ b/src/python/dual3.rs
@@ -5,7 +5,7 @@ use pyo3::prelude::*;
 
 #[pyclass(name = "Dual3_64")]
 #[derive(Clone)]
-/// Hyper dual number using 64-bit-floats.
+/// Third order dual number using 64-bit-floats as fields.
 pub struct PyDual3_64(Dual3_64);
 
 #[pymethods]
@@ -38,7 +38,7 @@ impl_dual_num!(PyDual3_64, Dual3_64, f64);
 
 #[pyclass(name = "Dual3Dual64")]
 #[derive(Clone)]
-/// Hyper dual number using 64-bit-floats.
+/// Third order dual number using dual numbers as fields.
 pub struct PyDual3Dual64(Dual3<Dual64, f64>);
 
 #[pymethods]

--- a/src/python/hyperdual.rs
+++ b/src/python/hyperdual.rs
@@ -1,19 +1,19 @@
 use super::dual::PyDual64;
-use super::dual2::{PyDual2Dual64, PyDual2_64};
+use super::dual2::{impl_dual2_n, PyDual2Dual64, PyDual2_64};
 use crate::*;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
 #[pyclass(name = "HyperDual64")]
 #[derive(Clone)]
-/// Hyper dual number using 64-bit-floats as fields.
+/// Hyper-dual number using 64-bit-floats as fields.
 ///
-/// A hyper dual number consists of
+/// A hyper-dual number consists of
 /// a + b ε1 + c ε2 + d ε1ε2
 ///
 /// Examples
 ///
-/// >>> from dualnum import HyperDual64 as HD64
+/// >>> from num_dual import HyperDual64 as HD64
 /// >>> x = HD64(1.0, 0.0, 0.0, 0.0) # constructor
 /// >>> y = HD64.from_re(2.0)        # from real value
 /// >>> x + y
@@ -21,7 +21,7 @@ use pyo3::prelude::*;
 ///
 /// Compute partial derivatives of a function.
 ///
-/// >>> from dualnum import HyperDual64 as HD64, derive2
+/// >>> from num_dual import HyperDual64 as HD64, derive2
 /// >>> x, y = derive2(3.0, 4.0)
 /// >>> # the above is equal to
 /// >>> x = HD64(3.0, 1.0, 0.0, 0.0)
@@ -59,7 +59,7 @@ impl_dual_num!(PyHyperDual64, HyperDual64, f64);
 
 #[pyclass(name = "HyperDualDual64")]
 #[derive(Clone)]
-/// Hyper dual number using dual numbers of 64-bit-floats.
+/// Hyper-dual number using dual numbers as fields.
 pub struct PyHyperDualDual64(HyperDual<Dual64, f64>);
 
 #[pymethods]
@@ -84,58 +84,11 @@ impl PyHyperDualDual64 {
 
 impl_dual_num!(PyHyperDualDual64, HyperDual<Dual64, f64>, PyDual64);
 
-macro_rules! impl_hyper_dual_n {
-    ($py_type_name:ident, $n:literal) => {
-        #[pyclass(name = "Dual2Vec64")]
-        #[derive(Clone, Copy)]
-        pub struct $py_type_name(Dual2Vec64<$n>);
-
-        impl $py_type_name {
-            pub fn new(re: f64, v1: [f64; $n], v2: [[f64; $n]; $n]) -> Self {
-                Dual2Vec64::new(re, StaticVec::new_vec(v1), StaticMat::new(v2)).into()
-            }
-        }
-
-        #[pymethods]
-        impl $py_type_name {
-            #[getter]
-            /// Gradient.
-            pub fn get_first_derivative(&self) -> [f64; $n] {
-                *self.0.v1.raw_array()
-            }
-
-            #[getter]
-            /// Hessian.
-            pub fn get_second_derivative(&self) -> Vec<Vec<f64>> {
-                self.0.v2.raw_data().iter().map(|a| a.to_vec()).collect()
-            }
-        }
-
-        impl_dual_num!($py_type_name, Dual2Vec64<$n>, f64);
-    };
-}
-
 macro_rules! impl_hyper_dual_mn {
     ($py_type_name:ident, $m:literal, $n:literal) => {
         #[pyclass(name = "HyperDualVec64")]
         #[derive(Clone, Copy)]
         pub struct $py_type_name(HyperDualVec64<$m, $n>);
-
-        impl $py_type_name {
-            pub fn new(
-                re: f64,
-                eps1: [f64; $m],
-                eps2: [f64; $n],
-                eps1eps2: [[f64; $n]; $m],
-            ) -> Self {
-                HyperDualVec64::new(
-                    re,
-                    StaticVec::new_vec(eps1),
-                    StaticVec::new_vec(eps2),
-                    StaticMat::new(eps1eps2),
-                ).into()
-            }
-        }
 
         #[pymethods]
         impl $py_type_name {
@@ -170,6 +123,10 @@ macro_rules! impl_derive {
                         if let Ok(x) = x1.extract::<PyDual64>() {
                             return Ok(PyCell::new(py, PyDual2Dual64::from(Dual2::from_re(x.into()).derive()))?.to_object(py));
                         };
+                        if let Ok([x]) = x1.extract::<[f64; 1]>() {
+                            let py_vec = vec![PyCell::new(py, PyDual2_64::from(Dual2_64::from_re(x).derive()))?];
+                            return Ok(py_vec.to_object(py));
+                        };
                         $(
                             if let Ok(x) = x1.extract::<[f64; $n]>() {
                                 let arr = StaticVec::new_vec(x).map(Dual2Vec64::from).derive();
@@ -177,6 +134,9 @@ macro_rules! impl_derive {
                                 return Ok(py_vec?.to_object(py));
                             };
                         )+
+                        if let Ok(_) = x1.extract::<Vec<f64>>() {
+                            return Err(PyErr::new::<PyTypeError, _>(format!("Second derivatives are only available for up to 5 variables!")))
+                        }
                     },
                     Some(x2) => {
                         if let (Ok(x1), Ok(x2)) = (x1.extract::<f64>(), x2.extract::<f64>()) {
@@ -186,6 +146,11 @@ macro_rules! impl_derive {
                             let py_x2 = PyCell::new(py, PyHyperDual64::from(x2));
                             return Ok((py_x1?, py_x2?).to_object(py));
                         };
+                        if let (Ok([x1]), Ok([x2])) = (x1.extract::<[f64; 1]>(), x2.extract::<[f64; 1]>()) {
+                            let py_vec1 = vec![PyCell::new(py, PyDual2_64::from(Dual2_64::from_re(x1).derive()))?];
+                            let py_vec2 = vec![PyCell::new(py, PyDual2_64::from(Dual2_64::from_re(x2).derive()))?];
+                            return Ok((py_vec1, py_vec2).to_object(py));
+                        };
                         $(
                             if let (Ok(x1), Ok(x2)) = (x1.extract::<f64>(), x2.extract::<[f64; $m]>()) {
                                 let x1 = HyperDualVec64::from(x1).derive1();
@@ -193,6 +158,13 @@ macro_rules! impl_derive {
                                 let py_x1 = PyCell::new(py, $py_type_name12::from(x1));
                                 let py_vec2: Result<Vec<&PyCell<$py_type_name12>>, _> = arr2.raw_array().iter().map(|&i| PyCell::new(py, $py_type_name12::from(i))).collect();
                                 return Ok((py_x1?, py_vec2?).to_object(py));
+                            };
+                            if let (Ok([x1]), Ok(x2)) = (x1.extract::<[f64; 1]>(), x2.extract::<[f64; $m]>()) {
+                                let x1 = HyperDualVec64::from(x1).derive1();
+                                let arr2 = StaticVec::new_vec(x2).map(HyperDualVec64::from).derive2();
+                                let py_vec1 = vec![PyCell::new(py, $py_type_name12::from(x1))?];
+                                let py_vec2: Result<Vec<&PyCell<$py_type_name12>>, _> = arr2.raw_array().iter().map(|&i| PyCell::new(py, $py_type_name12::from(i))).collect();
+                                return Ok((py_vec1, py_vec2?).to_object(py));
                             };
                         )+
                         $(
@@ -202,6 +174,13 @@ macro_rules! impl_derive {
                                 let py_vec1: Result<Vec<&PyCell<$py_type_name21>>, _> = arr1.raw_array().iter().map(|&i| PyCell::new(py, $py_type_name21::from(i))).collect();
                                 let py_x2 = PyCell::new(py, $py_type_name21::from(x2));
                                 return Ok((py_vec1?, py_x2?).to_object(py));
+                            };
+                            if let (Ok(x1), Ok([x2])) = (x1.extract::<[f64; $m]>(), x2.extract::<[f64; 1]>(), ) {
+                                let arr1 = StaticVec::new_vec(x1).map(HyperDualVec64::from).derive1();
+                                let x2 = HyperDualVec64::from(x2).derive2();
+                                let py_vec1: Result<Vec<&PyCell<$py_type_name21>>, _> = arr1.raw_array().iter().map(|&i| PyCell::new(py, $py_type_name21::from(i))).collect();
+                                let py_vec2 = vec![PyCell::new(py, $py_type_name21::from(x2))?];
+                                return Ok((py_vec1?, py_vec2).to_object(py));
                             };
                         )+
                         $(
@@ -213,12 +192,15 @@ macro_rules! impl_derive {
                                 return Ok((py_vec1?, py_vec2?).to_object(py));
                             };
                         )+
+                        if let (Ok(_), Ok(_)) = (x1.extract::<Vec<f64>>(), x2.extract::<Vec<f64>>()) {
+                            return Err(PyErr::new::<PyTypeError, _>(format!("Second derivatives are only available for up to 5 variables!")))
+                        }
                     }
                 };
                 Err(PyErr::new::<PyTypeError, _>(format!("not implemented!")))
             })
         }
-        $(impl_hyper_dual_n!($py_type_name, $n);)+
+        $(impl_dual2_n!($py_type_name, $n);)+
         $(impl_hyper_dual_mn!($py_type_name12, 1, $m);)+
         $(impl_hyper_dual_mn!($py_type_name21, $m, 1);)+
         $(impl_hyper_dual_mn!($py_type_name3, $m1, $m2);)+
@@ -226,14 +208,17 @@ macro_rules! impl_derive {
 }
 
 impl_derive!([
-    (PyHyperDual64_2, 2),
-    (PyHyperDual64_3, 3),
-    (PyHyperDual64_4, 4),
-    (PyHyperDual64_5, 5);
+    // Derivatives w.r.t. the same vector
+    (PyDual2_64_2, 2),
+    (PyDual2_64_3, 3),
+    (PyDual2_64_4, 4),
+    (PyDual2_64_5, 5);
+    // Derivatives w.r.t. a scalar and a vector
     (PyHyperDual64_1_2, PyHyperDual64_2_1, 2),
     (PyHyperDual64_1_3, PyHyperDual64_3_1, 3),
     (PyHyperDual64_1_4, PyHyperDual64_4_1, 4),
     (PyHyperDual64_1_5, PyHyperDual64_5_1, 5);
+    // Derivatives w.r.t. two vectors
     (PyHyperDual64_2_2, 2, 2),
     (PyHyperDual64_2_3, 2, 3),
     (PyHyperDual64_2_4, 2, 4),

--- a/src/python/macros.rs
+++ b/src/python/macros.rs
@@ -1,3 +1,4 @@
+#[macro_export]
 macro_rules! impl_dual_num {
     ($py_type_name:ty, $data_type:ty, $field_type:ty) => {
         impl From<$data_type> for $py_type_name {

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -12,10 +12,20 @@ use dual::derive1;
 use dual3::derive3;
 use hyperdual::derive2;
 
-pub use dual::PyDual64;
+pub use dual::{
+    PyDual64, PyDual64_10, PyDual64_2, PyDual64_3, PyDual64_4, PyDual64_5, PyDual64_6, PyDual64_7,
+    PyDual64_8, PyDual64_9,
+};
 pub use dual2::{PyDual2Dual64, PyDual2_64};
 pub use dual3::{PyDual3Dual64, PyDual3_64};
-pub use hyperdual::{PyHyperDual64, PyHyperDualDual64};
+pub use hyperdual::{
+    PyDual2_64_2, PyDual2_64_3, PyDual2_64_4, PyDual2_64_5, PyHyperDual64, PyHyperDual64_1_2,
+    PyHyperDual64_1_3, PyHyperDual64_1_4, PyHyperDual64_1_5, PyHyperDual64_2_1, PyHyperDual64_2_2,
+    PyHyperDual64_2_3, PyHyperDual64_2_4, PyHyperDual64_2_5, PyHyperDual64_3_1, PyHyperDual64_3_2,
+    PyHyperDual64_3_3, PyHyperDual64_3_4, PyHyperDual64_3_5, PyHyperDual64_4_1, PyHyperDual64_4_2,
+    PyHyperDual64_4_3, PyHyperDual64_4_4, PyHyperDual64_4_5, PyHyperDual64_5_1, PyHyperDual64_5_2,
+    PyHyperDual64_5_3, PyHyperDual64_5_4, PyHyperDual64_5_5, PyHyperDualDual64,
+};
 
 pub fn num_dual(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;


### PR DESCRIPTION
This PR exposes the python types of all vector dual numbers that are generated in macros. 

In addition to that some docstrings are cleared up and some additional cases are covered by the `derive` functions, e.g.:
```python
x,y = derive2(1, [2,3])        # already possible
x,y = derive2([1], [2,3])      # new in this PR
```
and the error message is improved slightly.