### PR TITLE
Added cases for `numpy.ndarray` as rhs argument to add, sub, mul and div

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,13 @@ exclude = ["/.github/*", "*.ipynb", "./docs/*"]
 [dependencies]
 num-traits = "0.2"
 pyo3 = { version = "0.16", optional = true }
-ndarray = { version = "0.15", optional = true }
+ndarray = "0.15"
+numpy = "0.16"
 
 [features]
 default = []
 python = ["pyo3"]
-linalg = ["ndarray"]
+linalg = []
 
 [dev-dependencies]
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ exclude = ["/.github/*", "*.ipynb", "./docs/*"]
 [dependencies]
 num-traits = "0.2"
 pyo3 = { version = "0.16", optional = true }
-ndarray = "0.15"
-numpy = "0.16"
+ndarray = { version = "0.15", optional = true }
+numpy = { version = "0.16", optional = true }
 
 [features]
 default = []
-python = ["pyo3"]
-linalg = []
+python = ["pyo3", "numpy", "ndarray"]
+linalg = ["ndarray"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/python/dual.rs
+++ b/src/python/dual.rs
@@ -1,9 +1,11 @@
 use crate::*;
+use numpy::{PyArray, PyReadonlyArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
+use pyo3::Python;
 
 #[pyclass(name = "Dual64")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// Dual number using 64-bit-floats as fields.
 ///
 /// A dual number consists of
@@ -45,6 +47,14 @@ impl PyDual64 {
         self.0.eps[0]
     }
 }
+
+// unsafe impl Element for PyDual64 {
+//     const IS_COPY: bool = false;
+
+//     fn get_dtype(py: Python) -> &numpy::PyArrayDescr {
+//         numpy::PyArrayDescr::object(py)
+//     }
+// }
 
 impl_dual_num!(PyDual64, Dual64, f64);
 

--- a/src/python/dual.rs
+++ b/src/python/dual.rs
@@ -48,14 +48,6 @@ impl PyDual64 {
     }
 }
 
-// unsafe impl Element for PyDual64 {
-//     const IS_COPY: bool = false;
-
-//     fn get_dtype(py: Python) -> &numpy::PyArrayDescr {
-//         numpy::PyArrayDescr::object(py)
-//     }
-// }
-
 impl_dual_num!(PyDual64, Dual64, f64);
 
 macro_rules! impl_dual_n {

--- a/src/python/dual2.rs
+++ b/src/python/dual2.rs
@@ -1,5 +1,6 @@
 use super::dual::PyDual64;
 use crate::*;
+use numpy::{PyArray, PyReadonlyArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 

--- a/src/python/dual3.rs
+++ b/src/python/dual3.rs
@@ -1,5 +1,6 @@
 use super::dual::PyDual64;
 use crate::*;
+use numpy::{PyArray, PyReadonlyArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 

--- a/src/python/hyperdual.rs
+++ b/src/python/hyperdual.rs
@@ -1,6 +1,7 @@
 use super::dual::PyDual64;
 use super::dual2::{impl_dual2_n, PyDual2Dual64, PyDual2_64};
 use crate::*;
+use numpy::{PyArray, PyReadonlyArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 

--- a/src/python/macros.rs
+++ b/src/python/macros.rs
@@ -253,6 +253,11 @@ macro_rules! impl_dual_num {
                                 }),
                             )
                             .into());
+                        } else {
+                            return Err(PyErr::new::<PyTypeError, _>(format!(
+                                "Operation with the provided object type is not implemented. Supported data types are 'float', 'int' and '{}'.",
+                                stringify!($py_type_name)
+                            )));
                         }
                     }
 
@@ -305,6 +310,11 @@ macro_rules! impl_dual_num {
                                 }),
                             )
                             .into());
+                        } else {
+                            return Err(PyErr::new::<PyTypeError, _>(format!(
+                                "Operation with the provided object type is not implemented. Supported data types are 'float', 'int' and '{}'.",
+                                stringify!($py_type_name)
+                            )));
                         }
                     }
 
@@ -357,6 +367,11 @@ macro_rules! impl_dual_num {
                                 }),
                             )
                             .into());
+                        } else {
+                            return Err(PyErr::new::<PyTypeError, _>(format!(
+                                "Operation with the provided object type is not implemented. Supported data types are 'float', 'int' and '{}'.",
+                                stringify!($py_type_name)
+                            )));
                         }
                     }
 
@@ -409,6 +424,11 @@ macro_rules! impl_dual_num {
                                 }),
                             )
                             .into());
+                        } else {
+                            return Err(PyErr::new::<PyTypeError, _>(format!(
+                                "Operation with the provided object type is not implemented. Supported data types are 'float', 'int' and '{}'.",
+                                stringify!($py_type_name)
+                            )));
                         }
                     }
 

--- a/tests/test_dual.rs
+++ b/tests/test_dual.rs
@@ -370,4 +370,3 @@ fn test_dual_bessel_j2_4() {
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.eps[0] - -0.132099570594364).abs() < 1e-12);
 }
-

--- a/tests/test_dual2.rs
+++ b/tests/test_dual2.rs
@@ -5,7 +5,7 @@ fn test_dual2_recip() {
     let res = Dual2_64::from(1.2).derive().recip();
     assert!((res.re - 0.833333333333333).abs() < 1e-12);
     assert!((res.v1[0] - -0.694444444444445).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 1.15740740740741).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 1.15740740740741).abs() < 1e-12);
 }
 
 #[test]
@@ -13,7 +13,7 @@ fn test_dual2_exp() {
     let res = Dual2_64::from(1.2).derive().exp();
     assert!((res.re - 3.32011692273655).abs() < 1e-12);
     assert!((res.v1[0] - 3.32011692273655).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 3.32011692273655).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 3.32011692273655).abs() < 1e-12);
 }
 
 #[test]
@@ -21,7 +21,7 @@ fn test_dual2_exp_m1() {
     let res = Dual2_64::from(1.2).derive().exp_m1();
     assert!((res.re - 2.32011692273655).abs() < 1e-12);
     assert!((res.v1[0] - 3.32011692273655).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 3.32011692273655).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 3.32011692273655).abs() < 1e-12);
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn test_dual2_exp2() {
     let res = Dual2_64::from(1.2).derive().exp2();
     assert!((res.re - 2.29739670999407).abs() < 1e-12);
     assert!((res.v1[0] - 1.59243405216008).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 1.10379117348241).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 1.10379117348241).abs() < 1e-12);
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn test_dual2_ln() {
     let res = Dual2_64::from(1.2).derive().ln();
     assert!((res.re - 0.182321556793955).abs() < 1e-12);
     assert!((res.v1[0] - 0.833333333333333).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.694444444444445).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.694444444444445).abs() < 1e-12);
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_dual2_log() {
     let res = Dual2_64::from(1.2).derive().log(4.2);
     assert!((res.re - 0.127045866345188).abs() < 1e-12);
     assert!((res.v1[0] - 0.580685888982970).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.483904907485808).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.483904907485808).abs() < 1e-12);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn test_dual2_ln_1p() {
     let res = Dual2_64::from(1.2).derive().ln_1p();
     assert!((res.re - 0.788457360364270).abs() < 1e-12);
     assert!((res.v1[0] - 0.454545454545455).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.206611570247934).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.206611570247934).abs() < 1e-12);
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn test_dual2_log2() {
     let res = Dual2_64::from(1.2).derive().log2();
     assert!((res.re - 0.263034405833794).abs() < 1e-12);
     assert!((res.v1[0] - 1.20224586740747).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -1.00187155617289).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -1.00187155617289).abs() < 1e-12);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_dual2_log10() {
     let res = Dual2_64::from(1.2).derive().log10();
     assert!((res.re - 0.0791812460476248).abs() < 1e-12);
     assert!((res.v1[0] - 0.361912068252710).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.301593390210592).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.301593390210592).abs() < 1e-12);
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn test_dual2_sqrt() {
     let res = Dual2_64::from(1.2).derive().sqrt();
     assert!((res.re - 1.09544511501033).abs() < 1e-12);
     assert!((res.v1[0] - 0.456435464587638).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.190181443578183).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.190181443578183).abs() < 1e-12);
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn test_dual2_cbrt() {
     let res = Dual2_64::from(1.2).derive().cbrt();
     assert!((res.re - 1.06265856918261).abs() < 1e-12);
     assert!((res.v1[0] - 0.295182935884059).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.163990519935588).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.163990519935588).abs() < 1e-12);
 }
 
 #[test]
@@ -93,7 +93,7 @@ fn test_dual2_powf() {
     let res = Dual2_64::from(1.2).derive().powf(4.2);
     assert!((res.re - 2.15060788316847).abs() < 1e-12);
     assert!((res.v1[0] - 7.52712759108966).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 20.0723402429058).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 20.0723402429058).abs() < 1e-12);
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn test_dual2_powf_0() {
     let res = Dual2_64::from(0.0).derive().powf(0.0);
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn test_dual2_powf_1() {
     let res = Dual2_64::from(0.0).derive().powf(1.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0] - 1.00000000000000).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn test_dual2_powf_2() {
     let res = Dual2_64::from(0.0).derive().powf(2.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 2.00000000000000).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 2.00000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn test_dual2_powf_3() {
     let res = Dual2_64::from(0.0).derive().powf(3.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn test_dual2_powf_4() {
     let res = Dual2_64::from(0.0).derive().powf(4.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -141,7 +141,7 @@ fn test_dual2_powi() {
     let res = Dual2_64::from(1.2).derive().powi(6);
     assert!((res.re - 2.98598400000000).abs() < 1e-12);
     assert!((res.v1[0] - 14.9299200000000).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 62.2080000000000).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 62.2080000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn test_dual2_powi_0() {
     let res = Dual2_64::from(0.0).derive().powi(0);
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -157,7 +157,7 @@ fn test_dual2_powi_1() {
     let res = Dual2_64::from(0.0).derive().powi(1);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0] - 1.00000000000000).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -165,7 +165,7 @@ fn test_dual2_powi_2() {
     let res = Dual2_64::from(0.0).derive().powi(2);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 2.00000000000000).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 2.00000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn test_dual2_powi_3() {
     let res = Dual2_64::from(0.0).derive().powi(3);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -181,7 +181,7 @@ fn test_dual2_powi_4() {
     let res = Dual2_64::from(0.0).derive().powi(4);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -189,7 +189,7 @@ fn test_dual2_sin() {
     let res = Dual2_64::from(1.2).derive().sin();
     assert!((res.re - 0.932039085967226).abs() < 1e-12);
     assert!((res.v1[0] - 0.362357754476674).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.932039085967226).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.932039085967226).abs() < 1e-12);
 }
 
 #[test]
@@ -197,7 +197,7 @@ fn test_dual2_cos() {
     let res = Dual2_64::from(1.2).derive().cos();
     assert!((res.re - 0.362357754476674).abs() < 1e-12);
     assert!((res.v1[0] - -0.932039085967226).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.362357754476674).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.362357754476674).abs() < 1e-12);
 }
 
 #[test]
@@ -205,7 +205,7 @@ fn test_dual2_tan() {
     let res = Dual2_64::from(1.2).derive().tan();
     assert!((res.re - 2.57215162212632).abs() < 1e-12);
     assert!((res.v1[0] - 7.61596396720705).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 39.1788281446144).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 39.1788281446144).abs() < 1e-12);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn test_dual2_asin() {
     let res = Dual2_64::from(0.2).derive().asin();
     assert!((res.re - 0.201357920790331).abs() < 1e-12);
     assert!((res.v1[0] - 1.02062072615966).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.212629317949929).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.212629317949929).abs() < 1e-12);
 }
 
 #[test]
@@ -221,7 +221,7 @@ fn test_dual2_acos() {
     let res = Dual2_64::from(0.2).derive().acos();
     assert!((res.re - 1.36943840600457).abs() < 1e-12);
     assert!((res.v1[0] - -1.02062072615966).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.212629317949929).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.212629317949929).abs() < 1e-12);
 }
 
 #[test]
@@ -229,7 +229,7 @@ fn test_dual2_atan() {
     let res = Dual2_64::from(0.2).derive().atan();
     assert!((res.re - 0.197395559849881).abs() < 1e-12);
     assert!((res.v1[0] - 0.961538461538462).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.369822485207101).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.369822485207101).abs() < 1e-12);
 }
 
 #[test]
@@ -237,7 +237,7 @@ fn test_dual2_sinh() {
     let res = Dual2_64::from(1.2).derive().sinh();
     assert!((res.re - 1.50946135541217).abs() < 1e-12);
     assert!((res.v1[0] - 1.81065556732437).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 1.50946135541217).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 1.50946135541217).abs() < 1e-12);
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn test_dual2_cosh() {
     let res = Dual2_64::from(1.2).derive().cosh();
     assert!((res.re - 1.81065556732437).abs() < 1e-12);
     assert!((res.v1[0] - 1.50946135541217).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 1.81065556732437).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 1.81065556732437).abs() < 1e-12);
 }
 
 #[test]
@@ -253,7 +253,7 @@ fn test_dual2_tanh() {
     let res = Dual2_64::from(1.2).derive().tanh();
     assert!((res.re - 0.833654607012155).abs() < 1e-12);
     assert!((res.v1[0] - 0.305019996207409).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.508562650138273).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.508562650138273).abs() < 1e-12);
 }
 
 #[test]
@@ -261,7 +261,7 @@ fn test_dual2_asinh() {
     let res = Dual2_64::from(1.2).derive().asinh();
     assert!((res.re - 1.01597313417969).abs() < 1e-12);
     assert!((res.v1[0] - 0.640184399664480).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.314844786720236).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.314844786720236).abs() < 1e-12);
 }
 
 #[test]
@@ -269,7 +269,7 @@ fn test_dual2_acosh() {
     let res = Dual2_64::from(1.2).derive().acosh();
     assert!((res.re - 0.622362503714779).abs() < 1e-12);
     assert!((res.v1[0] - 1.50755672288882).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -4.11151833515132).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -4.11151833515132).abs() < 1e-12);
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn test_dual2_atanh() {
     let res = Dual2_64::from(0.2).derive().atanh();
     assert!((res.re - 0.202732554054082).abs() < 1e-12);
     assert!((res.v1[0] - 1.04166666666667).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.434027777777778).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.434027777777778).abs() < 1e-12);
 }
 
 #[test]
@@ -285,7 +285,7 @@ fn test_dual2_sph_j0() {
     let res = Dual2_64::from(1.2).derive().sph_j0();
     assert!((res.re - 0.776699238306022).abs() < 1e-12);
     assert!((res.v1[0] - -0.345284569857790).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.201224955209705).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.201224955209705).abs() < 1e-12);
 }
 
 #[test]
@@ -293,7 +293,7 @@ fn test_dual2_sph_j1() {
     let res = Dual2_64::from(1.2).derive().sph_j1();
     assert!((res.re - 0.345284569857790).abs() < 1e-12);
     assert!((res.v1[0] - 0.201224955209705).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.201097592627034).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.201097592627034).abs() < 1e-12);
 }
 
 #[test]
@@ -301,7 +301,7 @@ fn test_dual2_sph_j2() {
     let res = Dual2_64::from(1.2).derive().sph_j2();
     assert!((res.re - 0.0865121863384538).abs() < 1e-12);
     assert!((res.v1[0] - 0.129004104011656).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.0589484167190109).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.0589484167190109).abs() < 1e-12);
 }
 
 #[test]
@@ -309,7 +309,7 @@ fn test_dual2_bessel_j0_0() {
     let res = Dual2_64::from(0.0).derive().bessel_j0();
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.500000000000000).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.500000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -317,7 +317,7 @@ fn test_dual2_bessel_j1_0() {
     let res = Dual2_64::from(0.0).derive().bessel_j1();
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0] - 0.500000000000000).abs() < 1e-12);
-    assert!((res.v2[(0,0)]).abs() < 1e-12);
+    assert!((res.v2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -325,7 +325,7 @@ fn test_dual2_bessel_j2_0() {
     let res = Dual2_64::from(0.0).derive().bessel_j2();
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.250000000000000).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.250000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -333,7 +333,7 @@ fn test_dual2_bessel_j0_1() {
     let res = Dual2_64::from(1.2).derive().bessel_j0();
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.v1[0] - -0.498289057567215).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.255891862958350).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.255891862958350).abs() < 1e-12);
 }
 
 #[test]
@@ -341,7 +341,7 @@ fn test_dual2_bessel_j1_1() {
     let res = Dual2_64::from(1.2).derive().bessel_j1();
     assert!((res.re - 0.498289057567215).abs() < 1e-12);
     assert!((res.v1[0] - 0.255891862958350).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.365498208944163).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.365498208944163).abs() < 1e-12);
 }
 
 #[test]
@@ -349,7 +349,7 @@ fn test_dual2_bessel_j2_1() {
     let res = Dual2_64::from(1.2).derive().bessel_j2();
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.v1[0] - 0.232707360321110).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.0893643434615870).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.0893643434615870).abs() < 1e-12);
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn test_dual2_bessel_j0_2() {
     let res = Dual2_64::from(7.2).derive().bessel_j0();
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.v1[0] - -0.0543274202223671).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.287525216370074).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.287525216370074).abs() < 1e-12);
 }
 
 #[test]
@@ -365,7 +365,7 @@ fn test_dual2_bessel_j1_2() {
     let res = Dual2_64::from(7.2).derive().bessel_j1();
     assert!((res.re - 0.0543274202223671).abs() < 1e-12);
     assert!((res.v1[0] - 0.287525216370074).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.0932134954083656).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.0932134954083656).abs() < 1e-12);
 }
 
 #[test]
@@ -373,7 +373,7 @@ fn test_dual2_bessel_j2_2() {
     let res = Dual2_64::from(7.2).derive().bessel_j2();
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.v1[0] - 0.132099570594364).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.240029203653306).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.240029203653306).abs() < 1e-12);
 }
 
 #[test]
@@ -381,7 +381,7 @@ fn test_dual2_bessel_j0_3() {
     let res = Dual2_64::from(-1.2).derive().bessel_j0();
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.v1[0] - 0.498289057567215).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.255891862958350).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.255891862958350).abs() < 1e-12);
 }
 
 #[test]
@@ -389,7 +389,7 @@ fn test_dual2_bessel_j1_3() {
     let res = Dual2_64::from(-1.2).derive().bessel_j1();
     assert!((res.re - -0.498289057567215).abs() < 1e-12);
     assert!((res.v1[0] - 0.255891862958350).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.365498208944163).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.365498208944163).abs() < 1e-12);
 }
 
 #[test]
@@ -397,7 +397,7 @@ fn test_dual2_bessel_j2_3() {
     let res = Dual2_64::from(-1.2).derive().bessel_j2();
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.v1[0] - -0.232707360321110).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.0893643434615870).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.0893643434615870).abs() < 1e-12);
 }
 
 #[test]
@@ -405,7 +405,7 @@ fn test_dual2_bessel_j0_4() {
     let res = Dual2_64::from(-7.2).derive().bessel_j0();
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.v1[0] - 0.0543274202223671).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - -0.287525216370074).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - -0.287525216370074).abs() < 1e-12);
 }
 
 #[test]
@@ -413,7 +413,7 @@ fn test_dual2_bessel_j1_4() {
     let res = Dual2_64::from(-7.2).derive().bessel_j1();
     assert!((res.re - -0.0543274202223671).abs() < 1e-12);
     assert!((res.v1[0] - 0.287525216370074).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.0932134954083656).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.0932134954083656).abs() < 1e-12);
 }
 
 #[test]
@@ -421,6 +421,5 @@ fn test_dual2_bessel_j2_4() {
     let res = Dual2_64::from(-7.2).derive().bessel_j2();
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.v1[0] - -0.132099570594364).abs() < 1e-12);
-    assert!((res.v2[(0,0)] - 0.240029203653306).abs() < 1e-12);
+    assert!((res.v2[(0, 0)] - 0.240029203653306).abs() < 1e-12);
 }
-

--- a/tests/test_dual2_vec.rs
+++ b/tests/test_dual2_vec.rs
@@ -1,5 +1,5 @@
-use num_traits::Zero;
 use num_dual::*;
+use num_traits::Zero;
 
 #[test]
 fn test_dual2_vec_recip() {
@@ -135,7 +135,8 @@ fn test_dual2_vec_cbrt() {
 
 #[test]
 fn test_dual2_vec_powf() {
-    let res = Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(4.2);
+    let res =
+        Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(4.2);
     assert!((res.re - 2.15060788316847).abs() < 1e-12);
     assert!((res.v1[0] - 7.52712759108966).abs() < 1e-12);
     assert!((res.v1[1] - 7.52712759108966).abs() < 1e-12);
@@ -147,7 +148,8 @@ fn test_dual2_vec_powf() {
 
 #[test]
 fn test_dual2_vec_powf_0() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(0.0);
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(0.0);
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
     assert!((res.v1[1]).abs() < 1e-12);
@@ -159,7 +161,8 @@ fn test_dual2_vec_powf_0() {
 
 #[test]
 fn test_dual2_vec_powf_1() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(1.0);
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(1.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0] - 1.00000000000000).abs() < 1e-12);
     assert!((res.v1[1] - 1.00000000000000).abs() < 1e-12);
@@ -171,7 +174,8 @@ fn test_dual2_vec_powf_1() {
 
 #[test]
 fn test_dual2_vec_powf_2() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(2.0);
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(2.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
     assert!((res.v1[1]).abs() < 1e-12);
@@ -183,7 +187,8 @@ fn test_dual2_vec_powf_2() {
 
 #[test]
 fn test_dual2_vec_powf_3() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(3.0);
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(3.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
     assert!((res.v1[1]).abs() < 1e-12);
@@ -195,7 +200,8 @@ fn test_dual2_vec_powf_3() {
 
 #[test]
 fn test_dual2_vec_powf_4() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(4.0);
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).powf(4.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
     assert!((res.v1[1]).abs() < 1e-12);
@@ -459,7 +465,8 @@ fn test_dual2_vec_sph_j2() {
 
 #[test]
 fn test_dual2_vec_bessel_j0_0() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
     assert!((res.v1[1]).abs() < 1e-12);
@@ -471,7 +478,8 @@ fn test_dual2_vec_bessel_j0_0() {
 
 #[test]
 fn test_dual2_vec_bessel_j1_0() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0] - 0.500000000000000).abs() < 1e-12);
     assert!((res.v1[1] - 0.500000000000000).abs() < 1e-12);
@@ -483,7 +491,8 @@ fn test_dual2_vec_bessel_j1_0() {
 
 #[test]
 fn test_dual2_vec_bessel_j2_0() {
-    let res = Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
+    let res =
+        Dual2Vec64::<2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
     assert!((res.re).abs() < 1e-12);
     assert!((res.v1[0]).abs() < 1e-12);
     assert!((res.v1[1]).abs() < 1e-12);
@@ -495,7 +504,8 @@ fn test_dual2_vec_bessel_j2_0() {
 
 #[test]
 fn test_dual2_vec_bessel_j0_1() {
-    let res = Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
+    let res =
+        Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.v1[0] - -0.498289057567215).abs() < 1e-12);
     assert!((res.v1[1] - -0.498289057567215).abs() < 1e-12);
@@ -507,7 +517,8 @@ fn test_dual2_vec_bessel_j0_1() {
 
 #[test]
 fn test_dual2_vec_bessel_j1_1() {
-    let res = Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
+    let res =
+        Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
     assert!((res.re - 0.498289057567215).abs() < 1e-12);
     assert!((res.v1[0] - 0.255891862958350).abs() < 1e-12);
     assert!((res.v1[1] - 0.255891862958350).abs() < 1e-12);
@@ -519,7 +530,8 @@ fn test_dual2_vec_bessel_j1_1() {
 
 #[test]
 fn test_dual2_vec_bessel_j2_1() {
-    let res = Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
+    let res =
+        Dual2Vec64::<2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.v1[0] - 0.232707360321110).abs() < 1e-12);
     assert!((res.v1[1] - 0.232707360321110).abs() < 1e-12);
@@ -531,7 +543,8 @@ fn test_dual2_vec_bessel_j2_1() {
 
 #[test]
 fn test_dual2_vec_bessel_j0_2() {
-    let res = Dual2Vec64::<2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
+    let res =
+        Dual2Vec64::<2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.v1[0] - -0.0543274202223671).abs() < 1e-12);
     assert!((res.v1[1] - -0.0543274202223671).abs() < 1e-12);
@@ -543,7 +556,8 @@ fn test_dual2_vec_bessel_j0_2() {
 
 #[test]
 fn test_dual2_vec_bessel_j1_2() {
-    let res = Dual2Vec64::<2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
+    let res =
+        Dual2Vec64::<2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
     assert!((res.re - 0.0543274202223671).abs() < 1e-12);
     assert!((res.v1[0] - 0.287525216370074).abs() < 1e-12);
     assert!((res.v1[1] - 0.287525216370074).abs() < 1e-12);
@@ -555,7 +569,8 @@ fn test_dual2_vec_bessel_j1_2() {
 
 #[test]
 fn test_dual2_vec_bessel_j2_2() {
-    let res = Dual2Vec64::<2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
+    let res =
+        Dual2Vec64::<2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.v1[0] - 0.132099570594364).abs() < 1e-12);
     assert!((res.v1[1] - 0.132099570594364).abs() < 1e-12);
@@ -567,7 +582,8 @@ fn test_dual2_vec_bessel_j2_2() {
 
 #[test]
 fn test_dual2_vec_bessel_j0_3() {
-    let res = Dual2Vec64::<2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
+    let res =
+        Dual2Vec64::<2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.v1[0] - 0.498289057567215).abs() < 1e-12);
     assert!((res.v1[1] - 0.498289057567215).abs() < 1e-12);
@@ -579,7 +595,8 @@ fn test_dual2_vec_bessel_j0_3() {
 
 #[test]
 fn test_dual2_vec_bessel_j1_3() {
-    let res = Dual2Vec64::<2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
+    let res =
+        Dual2Vec64::<2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
     assert!((res.re - -0.498289057567215).abs() < 1e-12);
     assert!((res.v1[0] - 0.255891862958350).abs() < 1e-12);
     assert!((res.v1[1] - 0.255891862958350).abs() < 1e-12);
@@ -591,7 +608,8 @@ fn test_dual2_vec_bessel_j1_3() {
 
 #[test]
 fn test_dual2_vec_bessel_j2_3() {
-    let res = Dual2Vec64::<2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
+    let res =
+        Dual2Vec64::<2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.v1[0] - -0.232707360321110).abs() < 1e-12);
     assert!((res.v1[1] - -0.232707360321110).abs() < 1e-12);
@@ -603,7 +621,8 @@ fn test_dual2_vec_bessel_j2_3() {
 
 #[test]
 fn test_dual2_vec_bessel_j0_4() {
-    let res = Dual2Vec64::<2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
+    let res =
+        Dual2Vec64::<2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j0();
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.v1[0] - 0.0543274202223671).abs() < 1e-12);
     assert!((res.v1[1] - 0.0543274202223671).abs() < 1e-12);
@@ -615,7 +634,8 @@ fn test_dual2_vec_bessel_j0_4() {
 
 #[test]
 fn test_dual2_vec_bessel_j1_4() {
-    let res = Dual2Vec64::<2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
+    let res =
+        Dual2Vec64::<2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j1();
     assert!((res.re - -0.0543274202223671).abs() < 1e-12);
     assert!((res.v1[0] - 0.287525216370074).abs() < 1e-12);
     assert!((res.v1[1] - 0.287525216370074).abs() < 1e-12);
@@ -627,7 +647,8 @@ fn test_dual2_vec_bessel_j1_4() {
 
 #[test]
 fn test_dual2_vec_bessel_j2_4() {
-    let res = Dual2Vec64::<2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
+    let res =
+        Dual2Vec64::<2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticMat::zero()).bessel_j2();
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.v1[0] - -0.132099570594364).abs() < 1e-12);
     assert!((res.v1[1] - -0.132099570594364).abs() < 1e-12);
@@ -636,4 +657,3 @@ fn test_dual2_vec_bessel_j2_4() {
     assert!((res.v2[(1, 0)] - 0.240029203653306).abs() < 1e-12);
     assert!((res.v2[(1, 1)] - 0.240029203653306).abs() < 1e-12);
 }
-

--- a/tests/test_dual3.rs
+++ b/tests/test_dual3.rs
@@ -476,4 +476,3 @@ fn test_dual3_bessel_j2_4() {
     assert!((res.v2 - 0.240029203653306).abs() < 1e-12);
     assert!((res.v3 - 0.146694937335182).abs() < 1e-12);
 }
-

--- a/tests/test_dual_vec.rs
+++ b/tests/test_dual_vec.rs
@@ -423,4 +423,3 @@ fn test_dual_vec_bessel_j2_4() {
     assert!((res.eps[0] - -0.132099570594364).abs() < 1e-12);
     assert!((res.eps[1] - -0.132099570594364).abs() < 1e-12);
 }
-

--- a/tests/test_hyperdual.rs
+++ b/tests/test_hyperdual.rs
@@ -6,7 +6,7 @@ fn test_hyperdual_recip() {
     assert!((res.re - 0.833333333333333).abs() < 1e-12);
     assert!((res.eps1[0] - -0.694444444444445).abs() < 1e-12);
     assert!((res.eps2[0] - -0.694444444444445).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 1.15740740740741).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 1.15740740740741).abs() < 1e-12);
 }
 
 #[test]
@@ -15,7 +15,7 @@ fn test_hyperdual_exp() {
     assert!((res.re - 3.32011692273655).abs() < 1e-12);
     assert!((res.eps1[0] - 3.32011692273655).abs() < 1e-12);
     assert!((res.eps2[0] - 3.32011692273655).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 3.32011692273655).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 3.32011692273655).abs() < 1e-12);
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn test_hyperdual_exp_m1() {
     assert!((res.re - 2.32011692273655).abs() < 1e-12);
     assert!((res.eps1[0] - 3.32011692273655).abs() < 1e-12);
     assert!((res.eps2[0] - 3.32011692273655).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 3.32011692273655).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 3.32011692273655).abs() < 1e-12);
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn test_hyperdual_exp2() {
     assert!((res.re - 2.29739670999407).abs() < 1e-12);
     assert!((res.eps1[0] - 1.59243405216008).abs() < 1e-12);
     assert!((res.eps2[0] - 1.59243405216008).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 1.10379117348241).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 1.10379117348241).abs() < 1e-12);
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn test_hyperdual_ln() {
     assert!((res.re - 0.182321556793955).abs() < 1e-12);
     assert!((res.eps1[0] - 0.833333333333333).abs() < 1e-12);
     assert!((res.eps2[0] - 0.833333333333333).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.694444444444445).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.694444444444445).abs() < 1e-12);
 }
 
 #[test]
@@ -51,7 +51,7 @@ fn test_hyperdual_log() {
     assert!((res.re - 0.127045866345188).abs() < 1e-12);
     assert!((res.eps1[0] - 0.580685888982970).abs() < 1e-12);
     assert!((res.eps2[0] - 0.580685888982970).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.483904907485808).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.483904907485808).abs() < 1e-12);
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn test_hyperdual_ln_1p() {
     assert!((res.re - 0.788457360364270).abs() < 1e-12);
     assert!((res.eps1[0] - 0.454545454545455).abs() < 1e-12);
     assert!((res.eps2[0] - 0.454545454545455).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.206611570247934).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.206611570247934).abs() < 1e-12);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_hyperdual_log2() {
     assert!((res.re - 0.263034405833794).abs() < 1e-12);
     assert!((res.eps1[0] - 1.20224586740747).abs() < 1e-12);
     assert!((res.eps2[0] - 1.20224586740747).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -1.00187155617289).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -1.00187155617289).abs() < 1e-12);
 }
 
 #[test]
@@ -78,7 +78,7 @@ fn test_hyperdual_log10() {
     assert!((res.re - 0.0791812460476248).abs() < 1e-12);
     assert!((res.eps1[0] - 0.361912068252710).abs() < 1e-12);
     assert!((res.eps2[0] - 0.361912068252710).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.301593390210592).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.301593390210592).abs() < 1e-12);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn test_hyperdual_sqrt() {
     assert!((res.re - 1.09544511501033).abs() < 1e-12);
     assert!((res.eps1[0] - 0.456435464587638).abs() < 1e-12);
     assert!((res.eps2[0] - 0.456435464587638).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.190181443578183).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.190181443578183).abs() < 1e-12);
 }
 
 #[test]
@@ -96,7 +96,7 @@ fn test_hyperdual_cbrt() {
     assert!((res.re - 1.06265856918261).abs() < 1e-12);
     assert!((res.eps1[0] - 0.295182935884059).abs() < 1e-12);
     assert!((res.eps2[0] - 0.295182935884059).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.163990519935588).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.163990519935588).abs() < 1e-12);
 }
 
 #[test]
@@ -105,7 +105,7 @@ fn test_hyperdual_powf() {
     assert!((res.re - 2.15060788316847).abs() < 1e-12);
     assert!((res.eps1[0] - 7.52712759108966).abs() < 1e-12);
     assert!((res.eps2[0] - 7.52712759108966).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 20.0723402429058).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 20.0723402429058).abs() < 1e-12);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn test_hyperdual_powf_0() {
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn test_hyperdual_powf_1() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0] - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps2[0] - 1.00000000000000).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn test_hyperdual_powf_2() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 2.00000000000000).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 2.00000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -141,7 +141,7 @@ fn test_hyperdual_powf_3() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn test_hyperdual_powf_4() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn test_hyperdual_powi() {
     assert!((res.re - 2.98598400000000).abs() < 1e-12);
     assert!((res.eps1[0] - 14.9299200000000).abs() < 1e-12);
     assert!((res.eps2[0] - 14.9299200000000).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 62.2080000000000).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 62.2080000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn test_hyperdual_powi_0() {
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn test_hyperdual_powi_1() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0] - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps2[0] - 1.00000000000000).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -186,7 +186,7 @@ fn test_hyperdual_powi_2() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 2.00000000000000).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 2.00000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -195,7 +195,7 @@ fn test_hyperdual_powi_3() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -204,7 +204,7 @@ fn test_hyperdual_powi_4() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn test_hyperdual_sin() {
     assert!((res.re - 0.932039085967226).abs() < 1e-12);
     assert!((res.eps1[0] - 0.362357754476674).abs() < 1e-12);
     assert!((res.eps2[0] - 0.362357754476674).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.932039085967226).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.932039085967226).abs() < 1e-12);
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn test_hyperdual_cos() {
     assert!((res.re - 0.362357754476674).abs() < 1e-12);
     assert!((res.eps1[0] - -0.932039085967226).abs() < 1e-12);
     assert!((res.eps2[0] - -0.932039085967226).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.362357754476674).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.362357754476674).abs() < 1e-12);
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn test_hyperdual_tan() {
     assert!((res.re - 2.57215162212632).abs() < 1e-12);
     assert!((res.eps1[0] - 7.61596396720705).abs() < 1e-12);
     assert!((res.eps2[0] - 7.61596396720705).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 39.1788281446144).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 39.1788281446144).abs() < 1e-12);
 }
 
 #[test]
@@ -240,7 +240,7 @@ fn test_hyperdual_asin() {
     assert!((res.re - 0.201357920790331).abs() < 1e-12);
     assert!((res.eps1[0] - 1.02062072615966).abs() < 1e-12);
     assert!((res.eps2[0] - 1.02062072615966).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.212629317949929).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.212629317949929).abs() < 1e-12);
 }
 
 #[test]
@@ -249,7 +249,7 @@ fn test_hyperdual_acos() {
     assert!((res.re - 1.36943840600457).abs() < 1e-12);
     assert!((res.eps1[0] - -1.02062072615966).abs() < 1e-12);
     assert!((res.eps2[0] - -1.02062072615966).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.212629317949929).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.212629317949929).abs() < 1e-12);
 }
 
 #[test]
@@ -258,7 +258,7 @@ fn test_hyperdual_atan() {
     assert!((res.re - 0.197395559849881).abs() < 1e-12);
     assert!((res.eps1[0] - 0.961538461538462).abs() < 1e-12);
     assert!((res.eps2[0] - 0.961538461538462).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.369822485207101).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.369822485207101).abs() < 1e-12);
 }
 
 #[test]
@@ -267,7 +267,7 @@ fn test_hyperdual_sinh() {
     assert!((res.re - 1.50946135541217).abs() < 1e-12);
     assert!((res.eps1[0] - 1.81065556732437).abs() < 1e-12);
     assert!((res.eps2[0] - 1.81065556732437).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 1.50946135541217).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 1.50946135541217).abs() < 1e-12);
 }
 
 #[test]
@@ -276,7 +276,7 @@ fn test_hyperdual_cosh() {
     assert!((res.re - 1.81065556732437).abs() < 1e-12);
     assert!((res.eps1[0] - 1.50946135541217).abs() < 1e-12);
     assert!((res.eps2[0] - 1.50946135541217).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 1.81065556732437).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 1.81065556732437).abs() < 1e-12);
 }
 
 #[test]
@@ -285,7 +285,7 @@ fn test_hyperdual_tanh() {
     assert!((res.re - 0.833654607012155).abs() < 1e-12);
     assert!((res.eps1[0] - 0.305019996207409).abs() < 1e-12);
     assert!((res.eps2[0] - 0.305019996207409).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.508562650138273).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.508562650138273).abs() < 1e-12);
 }
 
 #[test]
@@ -294,7 +294,7 @@ fn test_hyperdual_asinh() {
     assert!((res.re - 1.01597313417969).abs() < 1e-12);
     assert!((res.eps1[0] - 0.640184399664480).abs() < 1e-12);
     assert!((res.eps2[0] - 0.640184399664480).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.314844786720236).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.314844786720236).abs() < 1e-12);
 }
 
 #[test]
@@ -303,7 +303,7 @@ fn test_hyperdual_acosh() {
     assert!((res.re - 0.622362503714779).abs() < 1e-12);
     assert!((res.eps1[0] - 1.50755672288882).abs() < 1e-12);
     assert!((res.eps2[0] - 1.50755672288882).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -4.11151833515132).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -4.11151833515132).abs() < 1e-12);
 }
 
 #[test]
@@ -312,7 +312,7 @@ fn test_hyperdual_atanh() {
     assert!((res.re - 0.202732554054082).abs() < 1e-12);
     assert!((res.eps1[0] - 1.04166666666667).abs() < 1e-12);
     assert!((res.eps2[0] - 1.04166666666667).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.434027777777778).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.434027777777778).abs() < 1e-12);
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn test_hyperdual_sph_j0() {
     assert!((res.re - 0.776699238306022).abs() < 1e-12);
     assert!((res.eps1[0] - -0.345284569857790).abs() < 1e-12);
     assert!((res.eps2[0] - -0.345284569857790).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.201224955209705).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.201224955209705).abs() < 1e-12);
 }
 
 #[test]
@@ -330,7 +330,7 @@ fn test_hyperdual_sph_j1() {
     assert!((res.re - 0.345284569857790).abs() < 1e-12);
     assert!((res.eps1[0] - 0.201224955209705).abs() < 1e-12);
     assert!((res.eps2[0] - 0.201224955209705).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.201097592627034).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.201097592627034).abs() < 1e-12);
 }
 
 #[test]
@@ -339,7 +339,7 @@ fn test_hyperdual_sph_j2() {
     assert!((res.re - 0.0865121863384538).abs() < 1e-12);
     assert!((res.eps1[0] - 0.129004104011656).abs() < 1e-12);
     assert!((res.eps2[0] - 0.129004104011656).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.0589484167190109).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.0589484167190109).abs() < 1e-12);
 }
 
 #[test]
@@ -348,7 +348,7 @@ fn test_hyperdual_bessel_j0_0() {
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.500000000000000).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.500000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn test_hyperdual_bessel_j1_0() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0] - 0.500000000000000).abs() < 1e-12);
     assert!((res.eps2[0] - 0.500000000000000).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)]).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)]).abs() < 1e-12);
 }
 
 #[test]
@@ -366,7 +366,7 @@ fn test_hyperdual_bessel_j2_0() {
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps2[0]).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.250000000000000).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.250000000000000).abs() < 1e-12);
 }
 
 #[test]
@@ -375,7 +375,7 @@ fn test_hyperdual_bessel_j0_1() {
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.eps1[0] - -0.498289057567215).abs() < 1e-12);
     assert!((res.eps2[0] - -0.498289057567215).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.255891862958350).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.255891862958350).abs() < 1e-12);
 }
 
 #[test]
@@ -384,7 +384,7 @@ fn test_hyperdual_bessel_j1_1() {
     assert!((res.re - 0.498289057567215).abs() < 1e-12);
     assert!((res.eps1[0] - 0.255891862958350).abs() < 1e-12);
     assert!((res.eps2[0] - 0.255891862958350).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.365498208944163).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.365498208944163).abs() < 1e-12);
 }
 
 #[test]
@@ -393,7 +393,7 @@ fn test_hyperdual_bessel_j2_1() {
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.eps1[0] - 0.232707360321110).abs() < 1e-12);
     assert!((res.eps2[0] - 0.232707360321110).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.0893643434615870).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.0893643434615870).abs() < 1e-12);
 }
 
 #[test]
@@ -402,7 +402,7 @@ fn test_hyperdual_bessel_j0_2() {
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.eps1[0] - -0.0543274202223671).abs() < 1e-12);
     assert!((res.eps2[0] - -0.0543274202223671).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.287525216370074).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.287525216370074).abs() < 1e-12);
 }
 
 #[test]
@@ -411,7 +411,7 @@ fn test_hyperdual_bessel_j1_2() {
     assert!((res.re - 0.0543274202223671).abs() < 1e-12);
     assert!((res.eps1[0] - 0.287525216370074).abs() < 1e-12);
     assert!((res.eps2[0] - 0.287525216370074).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.0932134954083656).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.0932134954083656).abs() < 1e-12);
 }
 
 #[test]
@@ -420,7 +420,7 @@ fn test_hyperdual_bessel_j2_2() {
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.eps1[0] - 0.132099570594364).abs() < 1e-12);
     assert!((res.eps2[0] - 0.132099570594364).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.240029203653306).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.240029203653306).abs() < 1e-12);
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn test_hyperdual_bessel_j0_3() {
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.eps1[0] - 0.498289057567215).abs() < 1e-12);
     assert!((res.eps2[0] - 0.498289057567215).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.255891862958350).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.255891862958350).abs() < 1e-12);
 }
 
 #[test]
@@ -438,7 +438,7 @@ fn test_hyperdual_bessel_j1_3() {
     assert!((res.re - -0.498289057567215).abs() < 1e-12);
     assert!((res.eps1[0] - 0.255891862958350).abs() < 1e-12);
     assert!((res.eps2[0] - 0.255891862958350).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.365498208944163).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.365498208944163).abs() < 1e-12);
 }
 
 #[test]
@@ -447,7 +447,7 @@ fn test_hyperdual_bessel_j2_3() {
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.eps1[0] - -0.232707360321110).abs() < 1e-12);
     assert!((res.eps2[0] - -0.232707360321110).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.0893643434615870).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.0893643434615870).abs() < 1e-12);
 }
 
 #[test]
@@ -456,7 +456,7 @@ fn test_hyperdual_bessel_j0_4() {
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.eps1[0] - 0.0543274202223671).abs() < 1e-12);
     assert!((res.eps2[0] - 0.0543274202223671).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - -0.287525216370074).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - -0.287525216370074).abs() < 1e-12);
 }
 
 #[test]
@@ -465,7 +465,7 @@ fn test_hyperdual_bessel_j1_4() {
     assert!((res.re - -0.0543274202223671).abs() < 1e-12);
     assert!((res.eps1[0] - 0.287525216370074).abs() < 1e-12);
     assert!((res.eps2[0] - 0.287525216370074).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.0932134954083656).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.0932134954083656).abs() < 1e-12);
 }
 
 #[test]
@@ -474,6 +474,5 @@ fn test_hyperdual_bessel_j2_4() {
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.eps1[0] - -0.132099570594364).abs() < 1e-12);
     assert!((res.eps2[0] - -0.132099570594364).abs() < 1e-12);
-    assert!((res.eps1eps2[(0,0)] - 0.240029203653306).abs() < 1e-12);
+    assert!((res.eps1eps2[(0, 0)] - 0.240029203653306).abs() < 1e-12);
 }
-

--- a/tests/test_hyperdual_vec.rs
+++ b/tests/test_hyperdual_vec.rs
@@ -2,7 +2,13 @@ use num_dual::*;
 
 #[test]
 fn test_hyperdual_vec_recip() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).recip();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .recip();
     assert!((res.re - 0.833333333333333).abs() < 1e-12);
     assert!((res.eps1[0] - -0.694444444444445).abs() < 1e-12);
     assert!((res.eps1[1] - -0.694444444444445).abs() < 1e-12);
@@ -16,7 +22,13 @@ fn test_hyperdual_vec_recip() {
 
 #[test]
 fn test_hyperdual_vec_exp() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).exp();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .exp();
     assert!((res.re - 3.32011692273655).abs() < 1e-12);
     assert!((res.eps1[0] - 3.32011692273655).abs() < 1e-12);
     assert!((res.eps1[1] - 3.32011692273655).abs() < 1e-12);
@@ -30,7 +42,13 @@ fn test_hyperdual_vec_exp() {
 
 #[test]
 fn test_hyperdual_vec_exp_m1() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).exp_m1();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .exp_m1();
     assert!((res.re - 2.32011692273655).abs() < 1e-12);
     assert!((res.eps1[0] - 3.32011692273655).abs() < 1e-12);
     assert!((res.eps1[1] - 3.32011692273655).abs() < 1e-12);
@@ -44,7 +62,13 @@ fn test_hyperdual_vec_exp_m1() {
 
 #[test]
 fn test_hyperdual_vec_exp2() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).exp2();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .exp2();
     assert!((res.re - 2.29739670999407).abs() < 1e-12);
     assert!((res.eps1[0] - 1.59243405216008).abs() < 1e-12);
     assert!((res.eps1[1] - 1.59243405216008).abs() < 1e-12);
@@ -58,7 +82,13 @@ fn test_hyperdual_vec_exp2() {
 
 #[test]
 fn test_hyperdual_vec_ln() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).ln();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .ln();
     assert!((res.re - 0.182321556793955).abs() < 1e-12);
     assert!((res.eps1[0] - 0.833333333333333).abs() < 1e-12);
     assert!((res.eps1[1] - 0.833333333333333).abs() < 1e-12);
@@ -72,7 +102,13 @@ fn test_hyperdual_vec_ln() {
 
 #[test]
 fn test_hyperdual_vec_log() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).log(4.2);
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .log(4.2);
     assert!((res.re - 0.127045866345188).abs() < 1e-12);
     assert!((res.eps1[0] - 0.580685888982970).abs() < 1e-12);
     assert!((res.eps1[1] - 0.580685888982970).abs() < 1e-12);
@@ -86,7 +122,13 @@ fn test_hyperdual_vec_log() {
 
 #[test]
 fn test_hyperdual_vec_ln_1p() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).ln_1p();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .ln_1p();
     assert!((res.re - 0.788457360364270).abs() < 1e-12);
     assert!((res.eps1[0] - 0.454545454545455).abs() < 1e-12);
     assert!((res.eps1[1] - 0.454545454545455).abs() < 1e-12);
@@ -100,7 +142,13 @@ fn test_hyperdual_vec_ln_1p() {
 
 #[test]
 fn test_hyperdual_vec_log2() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).log2();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .log2();
     assert!((res.re - 0.263034405833794).abs() < 1e-12);
     assert!((res.eps1[0] - 1.20224586740747).abs() < 1e-12);
     assert!((res.eps1[1] - 1.20224586740747).abs() < 1e-12);
@@ -114,7 +162,13 @@ fn test_hyperdual_vec_log2() {
 
 #[test]
 fn test_hyperdual_vec_log10() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).log10();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .log10();
     assert!((res.re - 0.0791812460476248).abs() < 1e-12);
     assert!((res.eps1[0] - 0.361912068252710).abs() < 1e-12);
     assert!((res.eps1[1] - 0.361912068252710).abs() < 1e-12);
@@ -128,7 +182,13 @@ fn test_hyperdual_vec_log10() {
 
 #[test]
 fn test_hyperdual_vec_sqrt() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).sqrt();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .sqrt();
     assert!((res.re - 1.09544511501033).abs() < 1e-12);
     assert!((res.eps1[0] - 0.456435464587638).abs() < 1e-12);
     assert!((res.eps1[1] - 0.456435464587638).abs() < 1e-12);
@@ -142,7 +202,13 @@ fn test_hyperdual_vec_sqrt() {
 
 #[test]
 fn test_hyperdual_vec_cbrt() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).cbrt();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .cbrt();
     assert!((res.re - 1.06265856918261).abs() < 1e-12);
     assert!((res.eps1[0] - 0.295182935884059).abs() < 1e-12);
     assert!((res.eps1[1] - 0.295182935884059).abs() < 1e-12);
@@ -156,7 +222,13 @@ fn test_hyperdual_vec_cbrt() {
 
 #[test]
 fn test_hyperdual_vec_powf() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powf(4.2);
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powf(4.2);
     assert!((res.re - 2.15060788316847).abs() < 1e-12);
     assert!((res.eps1[0] - 7.52712759108966).abs() < 1e-12);
     assert!((res.eps1[1] - 7.52712759108966).abs() < 1e-12);
@@ -170,7 +242,13 @@ fn test_hyperdual_vec_powf() {
 
 #[test]
 fn test_hyperdual_vec_powf_0() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powf(0.0);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powf(0.0);
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -184,7 +262,13 @@ fn test_hyperdual_vec_powf_0() {
 
 #[test]
 fn test_hyperdual_vec_powf_1() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powf(1.0);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powf(1.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0] - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[1] - 1.00000000000000).abs() < 1e-12);
@@ -198,7 +282,13 @@ fn test_hyperdual_vec_powf_1() {
 
 #[test]
 fn test_hyperdual_vec_powf_2() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powf(2.0);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powf(2.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -212,7 +302,13 @@ fn test_hyperdual_vec_powf_2() {
 
 #[test]
 fn test_hyperdual_vec_powf_3() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powf(3.0);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powf(3.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -226,7 +322,13 @@ fn test_hyperdual_vec_powf_3() {
 
 #[test]
 fn test_hyperdual_vec_powf_4() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powf(4.0);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powf(4.0);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -240,7 +342,13 @@ fn test_hyperdual_vec_powf_4() {
 
 #[test]
 fn test_hyperdual_vec_powi() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powi(6);
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powi(6);
     assert!((res.re - 2.98598400000000).abs() < 1e-12);
     assert!((res.eps1[0] - 14.9299200000000).abs() < 1e-12);
     assert!((res.eps1[1] - 14.9299200000000).abs() < 1e-12);
@@ -254,7 +362,13 @@ fn test_hyperdual_vec_powi() {
 
 #[test]
 fn test_hyperdual_vec_powi_0() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powi(0);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powi(0);
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -268,7 +382,13 @@ fn test_hyperdual_vec_powi_0() {
 
 #[test]
 fn test_hyperdual_vec_powi_1() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powi(1);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powi(1);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0] - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[1] - 1.00000000000000).abs() < 1e-12);
@@ -282,7 +402,13 @@ fn test_hyperdual_vec_powi_1() {
 
 #[test]
 fn test_hyperdual_vec_powi_2() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powi(2);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powi(2);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -296,7 +422,13 @@ fn test_hyperdual_vec_powi_2() {
 
 #[test]
 fn test_hyperdual_vec_powi_3() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powi(3);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powi(3);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -310,7 +442,13 @@ fn test_hyperdual_vec_powi_3() {
 
 #[test]
 fn test_hyperdual_vec_powi_4() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).powi(4);
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .powi(4);
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -324,7 +462,13 @@ fn test_hyperdual_vec_powi_4() {
 
 #[test]
 fn test_hyperdual_vec_sin() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).sin();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .sin();
     assert!((res.re - 0.932039085967226).abs() < 1e-12);
     assert!((res.eps1[0] - 0.362357754476674).abs() < 1e-12);
     assert!((res.eps1[1] - 0.362357754476674).abs() < 1e-12);
@@ -338,7 +482,13 @@ fn test_hyperdual_vec_sin() {
 
 #[test]
 fn test_hyperdual_vec_cos() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).cos();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .cos();
     assert!((res.re - 0.362357754476674).abs() < 1e-12);
     assert!((res.eps1[0] - -0.932039085967226).abs() < 1e-12);
     assert!((res.eps1[1] - -0.932039085967226).abs() < 1e-12);
@@ -352,7 +502,13 @@ fn test_hyperdual_vec_cos() {
 
 #[test]
 fn test_hyperdual_vec_tan() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).tan();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .tan();
     assert!((res.re - 2.57215162212632).abs() < 1e-12);
     assert!((res.eps1[0] - 7.61596396720705).abs() < 1e-12);
     assert!((res.eps1[1] - 7.61596396720705).abs() < 1e-12);
@@ -366,7 +522,13 @@ fn test_hyperdual_vec_tan() {
 
 #[test]
 fn test_hyperdual_vec_asin() {
-    let res = HyperDualVec64::<2, 2>::new(0.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).asin();
+    let res = HyperDualVec64::<2, 2>::new(
+        0.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .asin();
     assert!((res.re - 0.201357920790331).abs() < 1e-12);
     assert!((res.eps1[0] - 1.02062072615966).abs() < 1e-12);
     assert!((res.eps1[1] - 1.02062072615966).abs() < 1e-12);
@@ -380,7 +542,13 @@ fn test_hyperdual_vec_asin() {
 
 #[test]
 fn test_hyperdual_vec_acos() {
-    let res = HyperDualVec64::<2, 2>::new(0.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).acos();
+    let res = HyperDualVec64::<2, 2>::new(
+        0.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .acos();
     assert!((res.re - 1.36943840600457).abs() < 1e-12);
     assert!((res.eps1[0] - -1.02062072615966).abs() < 1e-12);
     assert!((res.eps1[1] - -1.02062072615966).abs() < 1e-12);
@@ -394,7 +562,13 @@ fn test_hyperdual_vec_acos() {
 
 #[test]
 fn test_hyperdual_vec_atan() {
-    let res = HyperDualVec64::<2, 2>::new(0.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).atan();
+    let res = HyperDualVec64::<2, 2>::new(
+        0.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .atan();
     assert!((res.re - 0.197395559849881).abs() < 1e-12);
     assert!((res.eps1[0] - 0.961538461538462).abs() < 1e-12);
     assert!((res.eps1[1] - 0.961538461538462).abs() < 1e-12);
@@ -408,7 +582,13 @@ fn test_hyperdual_vec_atan() {
 
 #[test]
 fn test_hyperdual_vec_sinh() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).sinh();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .sinh();
     assert!((res.re - 1.50946135541217).abs() < 1e-12);
     assert!((res.eps1[0] - 1.81065556732437).abs() < 1e-12);
     assert!((res.eps1[1] - 1.81065556732437).abs() < 1e-12);
@@ -422,7 +602,13 @@ fn test_hyperdual_vec_sinh() {
 
 #[test]
 fn test_hyperdual_vec_cosh() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).cosh();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .cosh();
     assert!((res.re - 1.81065556732437).abs() < 1e-12);
     assert!((res.eps1[0] - 1.50946135541217).abs() < 1e-12);
     assert!((res.eps1[1] - 1.50946135541217).abs() < 1e-12);
@@ -436,7 +622,13 @@ fn test_hyperdual_vec_cosh() {
 
 #[test]
 fn test_hyperdual_vec_tanh() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).tanh();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .tanh();
     assert!((res.re - 0.833654607012155).abs() < 1e-12);
     assert!((res.eps1[0] - 0.305019996207409).abs() < 1e-12);
     assert!((res.eps1[1] - 0.305019996207409).abs() < 1e-12);
@@ -450,7 +642,13 @@ fn test_hyperdual_vec_tanh() {
 
 #[test]
 fn test_hyperdual_vec_asinh() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).asinh();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .asinh();
     assert!((res.re - 1.01597313417969).abs() < 1e-12);
     assert!((res.eps1[0] - 0.640184399664480).abs() < 1e-12);
     assert!((res.eps1[1] - 0.640184399664480).abs() < 1e-12);
@@ -464,7 +662,13 @@ fn test_hyperdual_vec_asinh() {
 
 #[test]
 fn test_hyperdual_vec_acosh() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).acosh();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .acosh();
     assert!((res.re - 0.622362503714779).abs() < 1e-12);
     assert!((res.eps1[0] - 1.50755672288882).abs() < 1e-12);
     assert!((res.eps1[1] - 1.50755672288882).abs() < 1e-12);
@@ -478,7 +682,13 @@ fn test_hyperdual_vec_acosh() {
 
 #[test]
 fn test_hyperdual_vec_atanh() {
-    let res = HyperDualVec64::<2, 2>::new(0.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).atanh();
+    let res = HyperDualVec64::<2, 2>::new(
+        0.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .atanh();
     assert!((res.re - 0.202732554054082).abs() < 1e-12);
     assert!((res.eps1[0] - 1.04166666666667).abs() < 1e-12);
     assert!((res.eps1[1] - 1.04166666666667).abs() < 1e-12);
@@ -492,7 +702,13 @@ fn test_hyperdual_vec_atanh() {
 
 #[test]
 fn test_hyperdual_vec_sph_j0() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).sph_j0();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .sph_j0();
     assert!((res.re - 0.776699238306022).abs() < 1e-12);
     assert!((res.eps1[0] - -0.345284569857790).abs() < 1e-12);
     assert!((res.eps1[1] - -0.345284569857790).abs() < 1e-12);
@@ -506,7 +722,13 @@ fn test_hyperdual_vec_sph_j0() {
 
 #[test]
 fn test_hyperdual_vec_sph_j1() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).sph_j1();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .sph_j1();
     assert!((res.re - 0.345284569857790).abs() < 1e-12);
     assert!((res.eps1[0] - 0.201224955209705).abs() < 1e-12);
     assert!((res.eps1[1] - 0.201224955209705).abs() < 1e-12);
@@ -520,7 +742,13 @@ fn test_hyperdual_vec_sph_j1() {
 
 #[test]
 fn test_hyperdual_vec_sph_j2() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).sph_j2();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .sph_j2();
     assert!((res.re - 0.0865121863384538).abs() < 1e-12);
     assert!((res.eps1[0] - 0.129004104011656).abs() < 1e-12);
     assert!((res.eps1[1] - 0.129004104011656).abs() < 1e-12);
@@ -534,7 +762,13 @@ fn test_hyperdual_vec_sph_j2() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j0_0() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j0();
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j0();
     assert!((res.re - 1.00000000000000).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -548,7 +782,13 @@ fn test_hyperdual_vec_bessel_j0_0() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j1_0() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j1();
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j1();
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0] - 0.500000000000000).abs() < 1e-12);
     assert!((res.eps1[1] - 0.500000000000000).abs() < 1e-12);
@@ -562,7 +802,13 @@ fn test_hyperdual_vec_bessel_j1_0() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j2_0() {
-    let res = HyperDualVec64::<2, 2>::new(0.0, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j2();
+    let res = HyperDualVec64::<2, 2>::new(
+        0.0,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j2();
     assert!((res.re).abs() < 1e-12);
     assert!((res.eps1[0]).abs() < 1e-12);
     assert!((res.eps1[1]).abs() < 1e-12);
@@ -576,7 +822,13 @@ fn test_hyperdual_vec_bessel_j2_0() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j0_1() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j0();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j0();
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.eps1[0] - -0.498289057567215).abs() < 1e-12);
     assert!((res.eps1[1] - -0.498289057567215).abs() < 1e-12);
@@ -590,7 +842,13 @@ fn test_hyperdual_vec_bessel_j0_1() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j1_1() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j1();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j1();
     assert!((res.re - 0.498289057567215).abs() < 1e-12);
     assert!((res.eps1[0] - 0.255891862958350).abs() < 1e-12);
     assert!((res.eps1[1] - 0.255891862958350).abs() < 1e-12);
@@ -604,7 +862,13 @@ fn test_hyperdual_vec_bessel_j1_1() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j2_1() {
-    let res = HyperDualVec64::<2, 2>::new(1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j2();
+    let res = HyperDualVec64::<2, 2>::new(
+        1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j2();
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.eps1[0] - 0.232707360321110).abs() < 1e-12);
     assert!((res.eps1[1] - 0.232707360321110).abs() < 1e-12);
@@ -618,7 +882,13 @@ fn test_hyperdual_vec_bessel_j2_1() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j0_2() {
-    let res = HyperDualVec64::<2, 2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j0();
+    let res = HyperDualVec64::<2, 2>::new(
+        7.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j0();
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.eps1[0] - -0.0543274202223671).abs() < 1e-12);
     assert!((res.eps1[1] - -0.0543274202223671).abs() < 1e-12);
@@ -632,7 +902,13 @@ fn test_hyperdual_vec_bessel_j0_2() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j1_2() {
-    let res = HyperDualVec64::<2, 2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j1();
+    let res = HyperDualVec64::<2, 2>::new(
+        7.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j1();
     assert!((res.re - 0.0543274202223671).abs() < 1e-12);
     assert!((res.eps1[0] - 0.287525216370074).abs() < 1e-12);
     assert!((res.eps1[1] - 0.287525216370074).abs() < 1e-12);
@@ -646,7 +922,13 @@ fn test_hyperdual_vec_bessel_j1_2() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j2_2() {
-    let res = HyperDualVec64::<2, 2>::new(7.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j2();
+    let res = HyperDualVec64::<2, 2>::new(
+        7.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j2();
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.eps1[0] - 0.132099570594364).abs() < 1e-12);
     assert!((res.eps1[1] - 0.132099570594364).abs() < 1e-12);
@@ -660,7 +942,13 @@ fn test_hyperdual_vec_bessel_j2_2() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j0_3() {
-    let res = HyperDualVec64::<2, 2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j0();
+    let res = HyperDualVec64::<2, 2>::new(
+        -1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j0();
     assert!((res.re - 0.671132744264363).abs() < 1e-12);
     assert!((res.eps1[0] - 0.498289057567215).abs() < 1e-12);
     assert!((res.eps1[1] - 0.498289057567215).abs() < 1e-12);
@@ -674,7 +962,13 @@ fn test_hyperdual_vec_bessel_j0_3() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j1_3() {
-    let res = HyperDualVec64::<2, 2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j1();
+    let res = HyperDualVec64::<2, 2>::new(
+        -1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j1();
     assert!((res.re - -0.498289057567215).abs() < 1e-12);
     assert!((res.eps1[0] - 0.255891862958350).abs() < 1e-12);
     assert!((res.eps1[1] - 0.255891862958350).abs() < 1e-12);
@@ -688,7 +982,13 @@ fn test_hyperdual_vec_bessel_j1_3() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j2_3() {
-    let res = HyperDualVec64::<2, 2>::new(-1.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j2();
+    let res = HyperDualVec64::<2, 2>::new(
+        -1.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j2();
     assert!((res.re - 0.159349018347663).abs() < 1e-12);
     assert!((res.eps1[0] - -0.232707360321110).abs() < 1e-12);
     assert!((res.eps1[1] - -0.232707360321110).abs() < 1e-12);
@@ -702,7 +1002,13 @@ fn test_hyperdual_vec_bessel_j2_3() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j0_4() {
-    let res = HyperDualVec64::<2, 2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j0();
+    let res = HyperDualVec64::<2, 2>::new(
+        -7.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j0();
     assert!((res.re - 0.295070691400958).abs() < 1e-12);
     assert!((res.eps1[0] - 0.0543274202223671).abs() < 1e-12);
     assert!((res.eps1[1] - 0.0543274202223671).abs() < 1e-12);
@@ -716,7 +1022,13 @@ fn test_hyperdual_vec_bessel_j0_4() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j1_4() {
-    let res = HyperDualVec64::<2, 2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j1();
+    let res = HyperDualVec64::<2, 2>::new(
+        -7.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j1();
     assert!((res.re - -0.0543274202223671).abs() < 1e-12);
     assert!((res.eps1[0] - 0.287525216370074).abs() < 1e-12);
     assert!((res.eps1[1] - 0.287525216370074).abs() < 1e-12);
@@ -730,7 +1042,13 @@ fn test_hyperdual_vec_bessel_j1_4() {
 
 #[test]
 fn test_hyperdual_vec_bessel_j2_4() {
-    let res = HyperDualVec64::<2, 2>::new(-7.2, StaticVec::new_vec([1.0, 1.0]), StaticVec::new_vec([1.0, 1.0]), StaticMat::new([[0.0, 0.0], [0.0, 0.0]])).bessel_j2();
+    let res = HyperDualVec64::<2, 2>::new(
+        -7.2,
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticVec::new_vec([1.0, 1.0]),
+        StaticMat::new([[0.0, 0.0], [0.0, 0.0]]),
+    )
+    .bessel_j2();
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.eps1[0] - -0.132099570594364).abs() < 1e-12);
     assert!((res.eps1[1] - -0.132099570594364).abs() < 1e-12);
@@ -741,4 +1059,3 @@ fn test_hyperdual_vec_bessel_j2_4() {
     assert!((res.eps1eps2[(1, 0)] - 0.240029203653306).abs() < 1e-12);
     assert!((res.eps1eps2[(1, 1)] - 0.240029203653306).abs() < 1e-12);
 }
-


### PR DESCRIPTION
Open points

- There are quite some `unwrap`s but it is not so easy to get rid of them within closures.
- Currently, I check the first entry of a `np.ndarray[Object]` to make sure it is of type `Self`. That's not an exhaustive check because an array `np.array([Dual64.from_re(1.0), "hi"])` would be considered as OK.
- The error message of an incompatible `np.ndarray[Object]` (where `Object != Self`) simply returns `<class numpy.ndarray>` which is not very helpful.