### PR TITLE
Add nalgebra compatibility for DualVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ pyo3 = { version = "0.18", optional = true, features = ["multiple-pymethods"] }
 ndarray = { version = "0.15", optional = true }
 numpy = { version = "0.18", optional = true }
 approx = "0.5"
+simba = "0.8"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ nalgebra = "0.32"
 pyo3 = { version = "0.18", optional = true, features = ["multiple-pymethods"] }
 ndarray = { version = "0.15", optional = true }
 numpy = { version = "0.18", optional = true }
+approx = "0.5"
 
 [profile.release]
 lto = true
@@ -30,7 +31,6 @@ linalg = ["ndarray"]
 
 [dev-dependencies]
 criterion = "0.4"
-approx = "0.5"
 
 [[bench]]
 name = "benchmark"

--- a/src/derivative.rs
+++ b/src/derivative.rs
@@ -4,7 +4,9 @@ use nalgebra::constraint::{SameNumberOfRows, ShapeConstraint};
 use nalgebra::*;
 use std::fmt;
 use std::marker::PhantomData;
+use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use num_traits::Zero;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Derivative<T: DualNum<F>, F, R: Dim, C: Dim>(
@@ -33,6 +35,83 @@ where
 
     pub fn none() -> Self {
         Self::new(None)
+    }
+
+    // A version of map that doesn't clone values before mapping. Useful for the SimdValue impl,
+    // which would be redundantly cloning all the lanes of each epsilon value before extracting
+    // just one of them.
+    //
+    // To implement, we inline a copy of Matrix::map, which implicitly clones values, and remove
+    // the cloning.
+    pub(crate) fn map_borrowed<T2, F2>(
+        &self,
+        mut f: impl FnMut(&T) -> T2,
+    ) -> Derivative<T2, F2, R, C>
+    where
+        T2: DualNum<F2>,
+        DefaultAllocator: Allocator<T2, R, C>,
+    {
+        let opt = self.0.as_ref().map(move |eps| {
+            let ref this = eps;
+            let mut f = |e| f(e);
+            let (nrows, ncols) = this.shape_generic();
+            let mut res: Matrix<MaybeUninit<T2>, R, C, _> = Matrix::uninit(nrows, ncols);
+
+            for j in 0..ncols.value() {
+                for i in 0..nrows.value() {
+                    // Safety: all indices are in range.
+                    unsafe {
+                        let a = this.data.get_unchecked(i, j);
+                        *res.data.get_unchecked_mut(i, j) = MaybeUninit::new(f(a));
+                    }
+                }
+            }
+
+            // Safety: res is now fully initialized.
+            unsafe { res.assume_init() }
+        });
+        Derivative::new(opt)
+    }
+
+    pub(crate) fn try_map_borrowed<T2, F2>(
+        &self,
+        mut f: impl FnMut(&T) -> Option<T2>,
+    ) -> Option<Derivative<T2, F2, R, C>>
+    where
+        T2: DualNum<F2>,
+        DefaultAllocator: Allocator<T2, R, C>,
+    {
+        self.0
+            .as_ref()
+            .and_then(move |eps| {
+                let ref this = eps;
+                let mut f = |e| f(e);
+                let (nrows, ncols) = this.shape_generic();
+                let mut res: Matrix<MaybeUninit<T2>, R, C, _> = Matrix::uninit(nrows, ncols);
+
+                for j in 0..ncols.value() {
+                    for i in 0..nrows.value() {
+                        // Safety: all indices are in range.
+                        unsafe {
+                            let a = this.data.get_unchecked(i, j);
+                            *res.data.get_unchecked_mut(i, j) = MaybeUninit::new(f(a)?);
+                        }
+                    }
+                }
+
+                // Safety: res is now fully initialized.
+                Some(unsafe { res.assume_init() })
+            })
+            .map(Derivative::some)
+    }
+
+    pub fn map<T2, F2>(&self, mut f: impl FnMut(T) -> T2) -> Derivative<T2, F2, R, C>
+    where
+        T2: DualNum<F2>,
+        DefaultAllocator: Allocator<T2, R, C>,
+    {
+        let opt = self.0.as_ref().map(move |eps| eps.map(|e| f(e)));
+        Derivative::new(opt)
     }
 
     pub fn derivative_generic(r: R, c: C, i: usize) -> Self {
@@ -302,5 +381,169 @@ where
             Some(s) => *s /= rhs,
             None => (),
         }
+    }
+}
+
+impl<T, R: Dim, C: Dim> nalgebra::SimdValue for Derivative<T, T::Element, R, C>
+where
+    DefaultAllocator: Allocator<T, R, C> + Allocator<T::Element, R, C>,
+    T: DualNum<T::Element> + SimdValue + Scalar,
+    T::Element: DualNum<T::Element> + Scalar + Zero,
+{
+    type Element = Derivative<T::Element, T::Element, R, C>;
+
+    type SimdBool = T::SimdBool;
+
+    #[inline]
+    fn lanes() -> usize {
+        T::lanes()
+    }
+
+    #[inline]
+    fn splat(val: Self::Element) -> Self {
+        val.map(|e| T::splat(e))
+    }
+
+    #[inline]
+    fn extract(&self, i: usize) -> Self::Element {
+        self.map_borrowed(|e| T::extract(e, i))
+    }
+
+    #[inline]
+    unsafe fn extract_unchecked(&self, i: usize) -> Self::Element {
+        let opt = self
+            .map_borrowed(|e| T::extract_unchecked(e, i))
+            .0
+            // Now check it's all zeros.
+            // Unfortunately there is no way to use the vectorized version of `is_zero`, which is
+            // only for matrices with statically known dimensions. Specialization would be
+            // required.
+            .filter(|x| Iterator::any(&mut x.iter(), |e| !e.is_zero()));
+        Derivative::new(opt)
+    }
+
+    // SIMD code will expect to be able to replace one lane with another Self::Element,
+    // even with a None Derivative, e.g.
+    //
+    // let single = Derivative::none();
+    // let mut x4 = Derivative::splat(single);
+    // let one = Derivative::some(...);
+    // x4.replace(1, one);
+    //
+    // So the implementation of `replace` will need to auto-upgrade to Some(zeros) in
+    // order to satisfy requests like that.
+    fn replace(&mut self, i: usize, val: Self::Element) {
+        match (&mut self.0, val.0) {
+            (Some(ours), Some(theirs)) => {
+                ours.zip_apply(&theirs, |e, replacement| e.replace(i, replacement));
+            }
+            (ours @ None, Some(theirs)) => {
+                let (r, c) = theirs.shape_generic();
+                let mut init: OMatrix<T, R, C> = OMatrix::zeros_generic(r, c);
+                init.zip_apply(&theirs, |e, replacement| e.replace(i, replacement));
+                *ours = Some(init);
+            }
+            (Some(ours), None) => {
+                ours.apply(|e| e.replace(i, T::Element::zero()));
+            }
+            _ => {}
+        }
+    }
+
+    unsafe fn replace_unchecked(&mut self, i: usize, val: Self::Element) {
+        match (&mut self.0, val.0) {
+            (Some(ours), Some(theirs)) => {
+                ours.zip_apply(&theirs, |e, replacement| {
+                    e.replace_unchecked(i, replacement)
+                });
+            }
+            (ours @ None, Some(theirs)) => {
+                let (r, c) = theirs.shape_generic();
+                let mut init: OMatrix<T, R, C> = OMatrix::zeros_generic(r, c);
+                init.zip_apply(&theirs, |e, replacement| {
+                    e.replace_unchecked(i, replacement)
+                });
+                *ours = Some(init);
+            }
+            (Some(ours), None) => {
+                ours.apply(|e| e.replace_unchecked(i, T::Element::zero()));
+            }
+            _ => {}
+        }
+    }
+
+    fn select(mut self, cond: Self::SimdBool, other: Self) -> Self {
+        // If cond is mixed, then we may need to generate big zero matrices to do the
+        // component-wise select on. So check if cond is all-true or all-first to avoid that.
+        if cond.all() {
+            self
+        } else if cond.none() {
+            other
+        } else {
+            match (&mut self.0, other.0) {
+                (Some(ours), Some(theirs)) => {
+                    ours.zip_apply(&theirs, |e, other_e| {
+                        // this will probably get optimized out
+                        let e_ = std::mem::replace(e, T::zero());
+                        *e = e_.select(cond, other_e)
+                    });
+                    self
+                }
+                (Some(ours), None) => {
+                    ours.apply(|e| {
+                        // this will probably get optimized out
+                        let e_ = std::mem::replace(e, T::zero());
+                        *e = e_.select(cond, T::zero());
+                    });
+                    self
+                }
+                (ours @ None, Some(mut theirs)) => {
+                    use std::ops::Not;
+                    let inverted: T::SimdBool = cond.not();
+                    theirs.apply(|e| {
+                        // this will probably get optimized out
+                        let e_ = std::mem::replace(e, T::zero());
+                        *e = e_.select(inverted, T::zero());
+                    });
+                    *ours = Some(theirs);
+                    self
+                }
+                _ => self,
+            }
+        }
+    }
+}
+
+use simba::scalar::{SubsetOf, SupersetOf};
+
+impl<TSuper, FSuper, T, F, R: Dim, C: Dim> SubsetOf<Derivative<TSuper, FSuper, R, C>>
+    for Derivative<T, F, R, C>
+where
+    TSuper: DualNum<FSuper> + SupersetOf<T>,
+    T: DualNum<F>,
+    DefaultAllocator: Allocator<T, R, C>,
+    DefaultAllocator: Allocator<TSuper, R, C>,
+    // DefaultAllocator: Allocator<TSuper, D>
+    //     + Allocator<TSuper, U1, D>
+    //     + Allocator<TSuper, D, U1>
+    //     + Allocator<TSuper, D, D>,
+{
+    #[inline(always)]
+    fn to_superset(&self) -> Derivative<TSuper, FSuper, R, C> {
+        self.map_borrowed(|elem| TSuper::from_subset(elem))
+    }
+    #[inline(always)]
+    fn from_superset(element: &Derivative<TSuper, FSuper, R, C>) -> Option<Self> {
+        element.try_map_borrowed(|elem| TSuper::to_subset(elem))
+    }
+    #[inline(always)]
+    fn from_superset_unchecked(element: &Derivative<TSuper, FSuper, R, C>) -> Self {
+        element.map_borrowed(|elem| TSuper::to_subset_unchecked(elem))
+    }
+    #[inline(always)]
+    fn is_in_subset(element: &Derivative<TSuper, FSuper, R, C>) -> bool {
+        element.0.as_ref().map_or(true, |matrix| {
+            matrix.iter().all(|elem| TSuper::is_in_subset(elem))
+        })
     }
 }

--- a/src/dual.rs
+++ b/src/dual.rs
@@ -645,7 +645,7 @@ where
 
     #[inline]
     fn norm1(self) -> Self::RealField {
-        panic!("called norm1() on a dual number")
+        self.abs()
     }
 
     #[inline]
@@ -873,12 +873,12 @@ where
 {
     #[inline]
     fn copysign(self, _sign: Self) -> Self {
-        todo!()
+        todo!("copysign not yet implemented on dual numbers")
     }
 
     #[inline]
     fn atan2(self, _other: Self) -> Self {
-        todo!()
+        todo!("atan2 not yet implemented on dual numbers")
     }
 
     #[inline]
@@ -966,10 +966,9 @@ where
         self.re.is_sign_negative()
     }
 
+    /// Got to be careful using this, because it throws away the derivatives of the one not chosen
     #[inline]
     fn max(self, other: Self) -> Self {
-        // Got to be careful using this, because you throw away the derivatives of the ones you
-        // don't use.
         if other > self {
             other
         } else {
@@ -977,9 +976,9 @@ where
         }
     }
 
+    /// Got to be careful using this, because it throws away the derivatives of the one not chosen
     #[inline]
     fn min(self, other: Self) -> Self {
-        // Got to be careful using this, because you throw away the derivatives of one of them.
         if other < self {
             other
         } else {
@@ -987,9 +986,9 @@ where
         }
     }
 
+    /// If the min/max values are constants and the clamping has an effect, you lose your gradients.
     #[inline]
     fn clamp(self, min: Self, max: Self) -> Self {
-        // Got to be careful using this, because you throw away the derivatives of one of them.
         if self < min {
             min
         } else if self > max {

--- a/src/dual.rs
+++ b/src/dual.rs
@@ -601,12 +601,12 @@ use nalgebra::{ComplexField, RealField};
 impl<T, D: Dim> ComplexField for DualVec<T, T::Element, D>
 where
     T: DualNum<T::Element> + SupersetOf<T> + AbsDiffEq<Epsilon = T> + Sync + Send,
-    T::Element: DualNum<T::Element> + Scalar + Float + Sync + Send,
+    T::Element: DualNum<T::Element> + Scalar + DualNumFloat + Sync + Send,
     T: SupersetOf<T::Element>,
     T: SupersetOf<f64>,
     T: SimdPartialOrd + PartialOrd,
     T: SimdValue<Element = T, SimdBool = bool>,
-    T: RelativeEq + UlpsEq + AbsDiffEq + From<f64>,
+    T: RelativeEq + UlpsEq + AbsDiffEq,
     DefaultAllocator:
         Allocator<T, D> + Allocator<T, U1, D> + Allocator<T, D, U1> + Allocator<T, D, D>,
     <DefaultAllocator as Allocator<T, D>>::Buffer: Sync + Send,
@@ -859,7 +859,7 @@ where
 impl<T, D: Dim> RealField for DualVec<T, T::Element, D>
 where
     T: DualNum<T::Element> + SupersetOf<T> + Sync + Send,
-    T::Element: DualNum<T::Element> + Scalar + Float + From<f64>,
+    T::Element: DualNum<T::Element> + Scalar + DualNumFloat,
     T: SupersetOf<T::Element>,
     T: SupersetOf<f64>,
     T: SimdPartialOrd + PartialOrd,
@@ -883,77 +883,77 @@ where
 
     #[inline]
     fn pi() -> Self {
-        Self::from_re(std::f64::consts::PI.into())
+        Self::from_re(<T as FloatConst>::PI())
     }
 
     #[inline]
     fn two_pi() -> Self {
-        Self::from_re(std::f64::consts::TAU.into())
+        Self::from_re(<T as FloatConst>::TAU())
     }
 
     #[inline]
     fn frac_pi_2() -> Self {
-        Self::from_re(std::f64::consts::FRAC_PI_4.into())
+        Self::from_re(<T as FloatConst>::FRAC_PI_4())
     }
 
     #[inline]
     fn frac_pi_3() -> Self {
-        Self::from_re(std::f64::consts::FRAC_PI_3.into())
+        Self::from_re(<T as FloatConst>::FRAC_PI_3())
     }
 
     #[inline]
     fn frac_pi_4() -> Self {
-        Self::from_re(std::f64::consts::FRAC_PI_4.into())
+        Self::from_re(<T as FloatConst>::FRAC_PI_4())
     }
 
     #[inline]
     fn frac_pi_6() -> Self {
-        Self::from_re(std::f64::consts::FRAC_PI_6.into())
+        Self::from_re(<T as FloatConst>::FRAC_PI_6())
     }
 
     #[inline]
     fn frac_pi_8() -> Self {
-        Self::from_re(std::f64::consts::FRAC_PI_8.into())
+        Self::from_re(<T as FloatConst>::FRAC_PI_8())
     }
 
     #[inline]
     fn frac_1_pi() -> Self {
-        Self::from_re(std::f64::consts::FRAC_1_PI.into())
+        Self::from_re(<T as FloatConst>::FRAC_1_PI())
     }
 
     #[inline]
     fn frac_2_pi() -> Self {
-        Self::from_re(std::f64::consts::FRAC_2_PI.into())
+        Self::from_re(<T as FloatConst>::FRAC_2_PI())
     }
 
     #[inline]
     fn frac_2_sqrt_pi() -> Self {
-        Self::from_re(std::f64::consts::FRAC_2_SQRT_PI.into())
+        Self::from_re(<T as FloatConst>::FRAC_2_SQRT_PI())
     }
 
     #[inline]
     fn e() -> Self {
-        Self::from_re(std::f64::consts::E.into())
+        Self::from_re(<T as FloatConst>::E())
     }
 
     #[inline]
     fn log2_e() -> Self {
-        Self::from_re(std::f64::consts::LOG2_E.into())
+        Self::from_re(<T as FloatConst>::LOG2_E())
     }
 
     #[inline]
     fn log10_e() -> Self {
-        Self::from_re(std::f64::consts::LOG10_E.into())
+        Self::from_re(<T as FloatConst>::LOG10_E())
     }
 
     #[inline]
     fn ln_2() -> Self {
-        Self::from_re(std::f64::consts::LN_2.into())
+        Self::from_re(<T as FloatConst>::LN_2())
     }
 
     #[inline]
     fn ln_10() -> Self {
-        Self::from_re(std::f64::consts::LN_10.into())
+        Self::from_re(<T as FloatConst>::LN_10())
     }
 
     #[inline]

--- a/src/dual.rs
+++ b/src/dual.rs
@@ -1,4 +1,5 @@
 use crate::{Derivative, DualNum, DualNumFloat};
+use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use nalgebra::allocator::Allocator;
 use nalgebra::*;
 use num_traits::{Float, FloatConst, FromPrimitive, Inv, Num, One, Signed, Zero};
@@ -286,25 +287,20 @@ impl_dual!(DualVec, [eps], [D]);
 
 /**
  * The SimdValue trait is for rearranging data into a form more suitable for Simd,
- * and rearranging it back into a usable form.
+ * and rearranging it back into a usable form. It is not documented particularly well.
  *
- * The primary job of this SimdValue impl is to allow people to use `simba::simd::AutoSimd`,
- * which implements the `num` traits, as their T, with our F parameter
- * set to <T as SimdValue>::Element. The AutoSimd type stores short arrays of floats etc, but
- * needs to be treated like a scalar. Therefore you need to be able to split up any type that
- * contains an AutoSimd<[f32; 4]> into four of your wrapper type. Then you can do normal math
- * operations on each one without having to know that underneath, everything was stored in
- * batches of [f32; 4]. But if you _do_ want to take advantage of SIMD instructions,
- * specialized implementations of `SimdRealField` can choose *not* to decompose the wrapper of
- * [f32; 4] into * individual wrappers of f32, and instead do bulk operations on the [f32; 4]s.
- * That's the idea. SimdValue is plumbing to be able to plug any wrapper type in to use
- * the non-specialized math operations that you would * find * in `nalgebra::RealField`.
- * `RealField` provides the default implementation of `SimdRealField`'s methods.
+ * The primary job of this SimdValue impl is to allow people to use `simba::simd::f32x4` etc,
+ * instead of f32/f64. Those types implement nalgebra::SimdRealField/ComplexField, so they
+ * behave like scalars. When we use them, we would have `DualVec<f32x4, f32, N>` etc, with our
+ * F parameter set to <T as SimdValue>::Element. We will need to be able to split up that type
+ * into four of DualVec in order to get out of simd-land. That's what the SimdValue trait is for.
  *
- * Ultimately, if you want more than _mere plumbing compatibility_ with AutoSimd and the like,
- * then you would have to implement SimdRealField on DualVec in such a way that it uses
- * SIMD instructions on particular CPUs. That's future work for someone who finds num_dual is not
- * fast enough.
+ * Ultimately, someone will have to to implement SimdRealField on DualVec and call the
+ * simd_ functions of <T as SimdRealField>. That's future work for someone who finds
+ * num_dual is not fast enough.
+ *
+ * Unfortunately, doing anything with SIMD is blocked on
+ * <https://github.com/dimforge/simba/issues/44>.
  *
  */
 impl<T, D: Dim> nalgebra::SimdValue for DualVec<T, T::Element, D>
@@ -313,17 +309,14 @@ where
     T: DualNum<T::Element> + SimdValue + Scalar,
     T::Element: DualNum<T::Element> + Scalar,
 {
-    // Say T = AutoSimd<[f32; 4]>. T::Element is f32. T::SimdBool is AutoSimd<[bool; 4]>.
+    // Say T = simba::f32x4. T::Element is f32. T::SimdBool is AutoSimd<[bool; 4]>.
     // AutoSimd<[f32; 4]> stores an actual [f32; 4], i.e. four floats in one slot.
     // So our DualVec<AutoSimd<[f32; 4], f32, N> has 4 * (1+N) floats in it, stored in blocks of
-    // four. When we want to do ANY math on it, we need to break that type into
-    // FOUR of DualVec<f32, f32, N>; then we do math on it, then we bring it back together. The
-    // SimdValue trait lets other nalgebra code do this:
+    // four. When we want to do any math on it but ignore its f32x4 storage mode, we need to break
+    // that type into FOUR of DualVec<f32, f32, N>; then we do math on it, then we bring it back
+    // together.
     //
-    // 1. Ask us how many lanes to use (4, because AutoSimd<[f32; 4]> says "4 lanes please")
-    // 2. Extract the  i-th lane, for i < 4, returning DualVec<f32, f32, N>.
-    // 2.
-    //
+    // Hence this definition of Element:
     type Element = DualVec<T::Element, T::Element, D>;
     type SimdBool = T::SimdBool;
 
@@ -416,32 +409,32 @@ where
 }
 /// Like PartialEq, comparisons are only made based on the real part. This allows the code to follow the
 /// same execution path as real-valued code would.
-impl<T: DualNum<F> + approx::AbsDiffEq<Epsilon = F>, F: Float, D: Dim> approx::AbsDiffEq
+impl<T: DualNum<F> + approx::AbsDiffEq<Epsilon = T>, F: Float, D: Dim> approx::AbsDiffEq
     for DualVec<T, F, D>
 where
     DefaultAllocator: Allocator<T, D>,
 {
-    type Epsilon = F;
+    type Epsilon = Self;
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        self.re.abs_diff_eq(&other.re, epsilon)
+        self.re.abs_diff_eq(&other.re, epsilon.re)
     }
 
     #[inline]
     fn default_epsilon() -> Self::Epsilon {
-        T::default_epsilon()
+        Self::from_re(T::default_epsilon())
     }
 }
 /// Like PartialEq, comparisons are only made based on the real part. This allows the code to follow the
 /// same execution path as real-valued code would.
-impl<T: DualNum<F> + approx::RelativeEq<Epsilon = F>, F: Float, D: Dim> approx::RelativeEq
+impl<T: DualNum<F> + approx::RelativeEq<Epsilon = T>, F: Float, D: Dim> approx::RelativeEq
     for DualVec<T, F, D>
 where
     DefaultAllocator: Allocator<T, D>,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
-        T::default_max_relative()
+        Self::from_re(T::default_max_relative())
     }
 
     #[inline]
@@ -451,6 +444,472 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        self.re.relative_eq(&other.re, epsilon, max_relative)
+        self.re.relative_eq(&other.re, epsilon.re, max_relative.re)
+    }
+}
+impl<T: DualNum<F> + UlpsEq<Epsilon = T>, F: Float, const N: usize> UlpsEq for DualVec<T, F, N> {
+    #[inline]
+    fn default_max_ulps() -> u32 {
+        T::default_max_ulps()
+    }
+
+    #[inline]
+    fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
+        T::ulps_eq(&self.re, &other.re, epsilon.re, max_ulps)
+    }
+}
+
+impl<T, const N: usize> nalgebra::Field for DualVec<T, T::Element, N>
+where
+    T: DualNum<T::Element> + SimdValue,
+    T::Element: DualNum<T::Element> + Scalar + Float,
+{
+}
+
+use simba::scalar::{SubsetOf, SupersetOf};
+
+impl<TSuper, FSuper, T, F, const N: usize> SubsetOf<DualVec<TSuper, FSuper, N>> for DualVec<T, F, N>
+where
+    TSuper: DualNum<FSuper> + SupersetOf<T>,
+    T: DualNum<F>,
+{
+    #[inline(always)]
+    fn to_superset(&self) -> DualVec<TSuper, FSuper, N> {
+        let re = TSuper::from_subset(&self.re);
+        let eps = SVector::<TSuper, N>::from_subset(&self.eps);
+        DualVec {
+            re,
+            eps,
+            f: PhantomData,
+        }
+    }
+    #[inline(always)]
+    fn from_superset(element: &DualVec<TSuper, FSuper, N>) -> Option<Self> {
+        let re = TSuper::to_subset(&element.re)?;
+        let eps = SVector::<TSuper, N>::to_subset(&element.eps)?;
+        Some(Self {
+            re,
+            eps,
+            f: PhantomData,
+        })
+    }
+    #[inline(always)]
+    fn from_superset_unchecked(element: &DualVec<TSuper, FSuper, N>) -> Self {
+        let re = TSuper::to_subset_unchecked(&element.re);
+        let eps = SVector::<TSuper, N>::to_subset_unchecked(&element.eps);
+        Self {
+            re,
+            eps,
+            f: PhantomData,
+        }
+    }
+    #[inline(always)]
+    fn is_in_subset(element: &DualVec<TSuper, FSuper, N>) -> bool {
+        TSuper::is_in_subset(&element.re)
+            && <SVector<TSuper, N> as SupersetOf<SVector<T, N>>>::is_in_subset(&element.eps)
+    }
+}
+
+impl<TSuper, FSuper, const N: usize> SupersetOf<f32> for DualVec<TSuper, FSuper, N>
+where
+    TSuper: DualNum<FSuper> + SupersetOf<f32>,
+{
+    #[inline(always)]
+    fn is_in_subset(&self) -> bool {
+        self.re.is_in_subset()
+    }
+
+    #[inline(always)]
+    fn to_subset_unchecked(&self) -> f32 {
+        self.re.to_subset_unchecked()
+    }
+
+    #[inline(always)]
+    fn from_subset(element: &f32) -> Self {
+        // Interpret as a purely real number
+        let re = TSuper::from_subset(element);
+        let eps = SVector::zeros();
+        Self {
+            re,
+            eps,
+            f: PhantomData,
+        }
+    }
+}
+
+impl<TSuper, FSuper, const N: usize> SupersetOf<f64> for DualVec<TSuper, FSuper, N>
+where
+    TSuper: DualNum<FSuper> + SupersetOf<f64>,
+{
+    #[inline(always)]
+    fn is_in_subset(&self) -> bool {
+        self.re.is_in_subset()
+    }
+
+    #[inline(always)]
+    fn to_subset_unchecked(&self) -> f64 {
+        self.re.to_subset_unchecked()
+    }
+
+    #[inline(always)]
+    fn from_subset(element: &f64) -> Self {
+        // Interpret as a purely real number
+        let re = TSuper::from_subset(element);
+        let eps = SVector::zeros();
+        Self {
+            re,
+            eps,
+            f: PhantomData,
+        }
+    }
+}
+
+// We can't do a simd implementation until simba lets us implement SimdPartialOrd
+// using _T_'s SimdBool. The blanket impl gets in the way. So we must constrain
+// T to SimdValue<Element = T, SimdBool = bool>, which is basically the same as
+// saying f32 or f64 only.
+//
+// Limitation of simba. See https://github.com/dimforge/simba/issues/44
+
+use nalgebra::{ComplexField, RealField};
+// This impl is modelled on `impl ComplexField for f32`. The imaginary part is nothing.
+impl<T, const N: usize> ComplexField for DualVec<T, T::Element, N>
+where
+    T: DualNum<T::Element> + SupersetOf<T> + AbsDiffEq<Epsilon = T>,
+    T::Element: DualNum<T::Element> + Scalar + Float,
+    T: SupersetOf<T::Element>,
+    T: SupersetOf<f64>,
+    T: SimdPartialOrd + PartialOrd,
+    T: SimdValue<Element = T, SimdBool = bool>,
+    T: RelativeEq + UlpsEq + AbsDiffEq + From<f64>,
+{
+    type RealField = Self;
+
+    #[inline]
+    fn from_real(re: Self::RealField) -> Self {
+        re
+    }
+
+    #[inline]
+    fn real(self) -> Self::RealField {
+        self
+    }
+
+    #[inline]
+    fn imaginary(self) -> Self::RealField {
+        Self::zero()
+    }
+
+    #[inline]
+    fn modulus(self) -> Self::RealField {
+        self.abs()
+    }
+
+    fn modulus_squared(self) -> Self::RealField {
+        self * self
+    }
+
+    fn argument(self) -> Self::RealField {
+        Self::zero()
+    }
+
+    fn norm1(self) -> Self::RealField {
+        panic!("called norm1() on a dual number")
+    }
+
+    fn scale(self, factor: Self::RealField) -> Self {
+        self * factor
+    }
+
+    fn unscale(self, factor: Self::RealField) -> Self {
+        self / factor
+    }
+
+    fn floor(self) -> Self {
+        panic!("called floor() on a dual number")
+    }
+
+    fn ceil(self) -> Self {
+        panic!("called ceil() on a dual number")
+    }
+
+    fn round(self) -> Self {
+        panic!("called round() on a dual number")
+    }
+
+    fn trunc(self) -> Self {
+        panic!("called trunc() on a dual number")
+    }
+
+    fn fract(self) -> Self {
+        panic!("called fract() on a dual number")
+    }
+
+    fn mul_add(self, a: Self, b: Self) -> Self {
+        DualNum::mul_add(&self, a, b)
+    }
+
+    fn abs(self) -> Self::RealField {
+        Signed::abs(&self)
+    }
+
+    fn hypot(self, other: Self) -> Self::RealField {
+        let sum_sq = self.powi(2) + other.powi(2);
+        DualNum::sqrt(&sum_sq)
+    }
+
+    fn recip(self) -> Self {
+        DualNum::recip(&self)
+    }
+
+    fn conjugate(self) -> Self {
+        self
+    }
+
+    fn sin(self) -> Self {
+        DualNum::sin(&self)
+    }
+
+    fn cos(self) -> Self {
+        DualNum::cos(&self)
+    }
+
+    fn sin_cos(self) -> (Self, Self) {
+        DualNum::sin_cos(&self)
+    }
+
+    fn tan(self) -> Self {
+        DualNum::tan(&self)
+    }
+
+    fn asin(self) -> Self {
+        DualNum::asin(&self)
+    }
+
+    fn acos(self) -> Self {
+        DualNum::acos(&self)
+    }
+
+    fn atan(self) -> Self {
+        DualNum::atan(&self)
+    }
+
+    fn sinh(self) -> Self {
+        DualNum::sinh(&self)
+    }
+
+    fn cosh(self) -> Self {
+        DualNum::cosh(&self)
+    }
+
+    fn tanh(self) -> Self {
+        DualNum::tanh(&self)
+    }
+
+    fn asinh(self) -> Self {
+        DualNum::asinh(&self)
+    }
+
+    fn acosh(self) -> Self {
+        DualNum::acosh(&self)
+    }
+
+    fn atanh(self) -> Self {
+        DualNum::atanh(&self)
+    }
+
+    fn log(self, base: Self::RealField) -> Self {
+        DualNum::ln(&self) / DualNum::ln(&base)
+    }
+
+    fn log2(self) -> Self {
+        DualNum::log2(&self)
+    }
+
+    fn log10(self) -> Self {
+        DualNum::log10(&self)
+    }
+
+    fn ln(self) -> Self {
+        DualNum::ln(&self)
+    }
+
+    fn ln_1p(self) -> Self {
+        DualNum::ln_1p(&self)
+    }
+
+    fn sqrt(self) -> Self {
+        DualNum::sqrt(&self)
+    }
+
+    fn exp(self) -> Self {
+        DualNum::exp(&self)
+    }
+
+    fn exp2(self) -> Self {
+        DualNum::exp2(&self)
+    }
+
+    fn exp_m1(self) -> Self {
+        DualNum::exp_m1(&self)
+    }
+
+    fn powi(self, n: i32) -> Self {
+        DualNum::powi(&self, n)
+    }
+
+    fn powf(self, n: Self::RealField) -> Self {
+        // n could be a dual.
+        DualNum::powd(&self, n)
+    }
+
+    fn powc(self, n: Self) -> Self {
+        // same as powf, Self isn't complex
+        self.powf(n)
+    }
+
+    fn cbrt(self) -> Self {
+        DualNum::cbrt(&self)
+    }
+
+    #[inline]
+    fn is_finite(&self) -> bool {
+        self.re.is_finite()
+    }
+
+    #[inline]
+    fn try_sqrt(self) -> Option<Self> {
+        if self > Self::zero() {
+            Some(DualNum::sqrt(&self))
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, const N: usize> RealField for DualVec<T, T::Element, N>
+where
+    T: DualNum<T::Element> + SupersetOf<T>,
+    T::Element: DualNum<T::Element> + Scalar + Float + From<f64>,
+    T: SupersetOf<T::Element>,
+    T: SupersetOf<f64>,
+    T: SimdPartialOrd + PartialOrd,
+    T: RelativeEq + AbsDiffEq<Epsilon = T>,
+    T: SimdValue<Element = T, SimdBool = bool>,
+    T: UlpsEq,
+    T: AbsDiffEq,
+{
+    fn copysign(self, _sign: Self) -> Self {
+        todo!()
+    }
+
+    fn atan2(self, _other: Self) -> Self {
+        todo!()
+    }
+
+    fn pi() -> Self {
+        Self::from_re(std::f64::consts::PI.into())
+    }
+
+    fn two_pi() -> Self {
+        Self::from_re(std::f64::consts::TAU.into())
+    }
+
+    fn frac_pi_2() -> Self {
+        Self::from_re(std::f64::consts::FRAC_PI_4.into())
+    }
+
+    fn frac_pi_3() -> Self {
+        Self::from_re(std::f64::consts::FRAC_PI_3.into())
+    }
+
+    fn frac_pi_4() -> Self {
+        Self::from_re(std::f64::consts::FRAC_PI_4.into())
+    }
+
+    fn frac_pi_6() -> Self {
+        Self::from_re(std::f64::consts::FRAC_PI_6.into())
+    }
+
+    fn frac_pi_8() -> Self {
+        Self::from_re(std::f64::consts::FRAC_PI_8.into())
+    }
+
+    fn frac_1_pi() -> Self {
+        Self::from_re(std::f64::consts::FRAC_1_PI.into())
+    }
+
+    fn frac_2_pi() -> Self {
+        Self::from_re(std::f64::consts::FRAC_2_PI.into())
+    }
+
+    fn frac_2_sqrt_pi() -> Self {
+        Self::from_re(std::f64::consts::FRAC_2_SQRT_PI.into())
+    }
+
+    fn e() -> Self {
+        Self::from_re(std::f64::consts::E.into())
+    }
+
+    fn log2_e() -> Self {
+        Self::from_re(std::f64::consts::LOG2_E.into())
+    }
+
+    fn log10_e() -> Self {
+        Self::from_re(std::f64::consts::LOG10_E.into())
+    }
+
+    fn ln_2() -> Self {
+        Self::from_re(std::f64::consts::LN_2.into())
+    }
+
+    fn ln_10() -> Self {
+        Self::from_re(std::f64::consts::LN_10.into())
+    }
+
+    fn is_sign_positive(&self) -> bool {
+        self.re.is_sign_positive()
+    }
+
+    fn is_sign_negative(&self) -> bool {
+        self.re.is_sign_negative()
+    }
+
+    fn max(self, other: Self) -> Self {
+        // Got to be careful using this, because you throw away the derivatives of the ones you
+        // don't use.
+        if other > self {
+            other
+        } else {
+            self
+        }
+    }
+
+    fn min(self, other: Self) -> Self {
+        // Got to be careful using this, because you throw away the derivatives of one of them.
+        if other < self {
+            other
+        } else {
+            self
+        }
+    }
+
+    fn clamp(self, min: Self, max: Self) -> Self {
+        // Got to be careful using this, because you throw away the derivatives of one of them.
+        if self < min {
+            min
+        } else if self > max {
+            max
+        } else {
+            self
+        }
+    }
+
+    fn min_value() -> Option<Self> {
+        Some(Self::from_re(T::min_value()))
+    }
+
+    fn max_value() -> Option<Self> {
+        Some(Self::from_re(T::max_value()))
     }
 }

--- a/src/dual.rs
+++ b/src/dual.rs
@@ -633,169 +633,210 @@ where
         self.abs()
     }
 
+    #[inline]
     fn modulus_squared(self) -> Self::RealField {
         &self * &self
     }
 
+    #[inline]
     fn argument(self) -> Self::RealField {
         Self::zero()
     }
 
+    #[inline]
     fn norm1(self) -> Self::RealField {
         panic!("called norm1() on a dual number")
     }
 
+    #[inline]
     fn scale(self, factor: Self::RealField) -> Self {
         self * factor
     }
 
+    #[inline]
     fn unscale(self, factor: Self::RealField) -> Self {
         self / factor
     }
 
+    #[inline]
     fn floor(self) -> Self {
         panic!("called floor() on a dual number")
     }
 
+    #[inline]
     fn ceil(self) -> Self {
         panic!("called ceil() on a dual number")
     }
 
+    #[inline]
     fn round(self) -> Self {
         panic!("called round() on a dual number")
     }
 
+    #[inline]
     fn trunc(self) -> Self {
         panic!("called trunc() on a dual number")
     }
 
+    #[inline]
     fn fract(self) -> Self {
         panic!("called fract() on a dual number")
     }
 
+    #[inline]
     fn mul_add(self, a: Self, b: Self) -> Self {
         DualNum::mul_add(&self, a, b)
     }
 
+    #[inline]
     fn abs(self) -> Self::RealField {
         Signed::abs(&self)
     }
 
+    #[inline]
     fn hypot(self, other: Self) -> Self::RealField {
         let sum_sq = self.powi(2) + other.powi(2);
         DualNum::sqrt(&sum_sq)
     }
 
+    #[inline]
     fn recip(self) -> Self {
         DualNum::recip(&self)
     }
 
+    #[inline]
     fn conjugate(self) -> Self {
         self
     }
 
+    #[inline]
     fn sin(self) -> Self {
         DualNum::sin(&self)
     }
 
+    #[inline]
     fn cos(self) -> Self {
         DualNum::cos(&self)
     }
 
+    #[inline]
     fn sin_cos(self) -> (Self, Self) {
         DualNum::sin_cos(&self)
     }
 
+    #[inline]
     fn tan(self) -> Self {
         DualNum::tan(&self)
     }
 
+    #[inline]
     fn asin(self) -> Self {
         DualNum::asin(&self)
     }
 
+    #[inline]
     fn acos(self) -> Self {
         DualNum::acos(&self)
     }
 
+    #[inline]
     fn atan(self) -> Self {
         DualNum::atan(&self)
     }
 
+    #[inline]
     fn sinh(self) -> Self {
         DualNum::sinh(&self)
     }
 
+    #[inline]
     fn cosh(self) -> Self {
         DualNum::cosh(&self)
     }
 
+    #[inline]
     fn tanh(self) -> Self {
         DualNum::tanh(&self)
     }
 
+    #[inline]
     fn asinh(self) -> Self {
         DualNum::asinh(&self)
     }
 
+    #[inline]
     fn acosh(self) -> Self {
         DualNum::acosh(&self)
     }
 
+    #[inline]
     fn atanh(self) -> Self {
         DualNum::atanh(&self)
     }
 
+    #[inline]
     fn log(self, base: Self::RealField) -> Self {
         DualNum::ln(&self) / DualNum::ln(&base)
     }
 
+    #[inline]
     fn log2(self) -> Self {
         DualNum::log2(&self)
     }
 
+    #[inline]
     fn log10(self) -> Self {
         DualNum::log10(&self)
     }
 
+    #[inline]
     fn ln(self) -> Self {
         DualNum::ln(&self)
     }
 
+    #[inline]
     fn ln_1p(self) -> Self {
         DualNum::ln_1p(&self)
     }
 
+    #[inline]
     fn sqrt(self) -> Self {
         DualNum::sqrt(&self)
     }
 
+    #[inline]
     fn exp(self) -> Self {
         DualNum::exp(&self)
     }
 
+    #[inline]
     fn exp2(self) -> Self {
         DualNum::exp2(&self)
     }
 
+    #[inline]
     fn exp_m1(self) -> Self {
         DualNum::exp_m1(&self)
     }
 
+    #[inline]
     fn powi(self, n: i32) -> Self {
         DualNum::powi(&self, n)
     }
 
+    #[inline]
     fn powf(self, n: Self::RealField) -> Self {
         // n could be a dual.
         DualNum::powd(&self, n)
     }
 
+    #[inline]
     fn powc(self, n: Self) -> Self {
         // same as powf, Self isn't complex
         self.powf(n)
     }
 
+    #[inline]
     fn cbrt(self) -> Self {
         DualNum::cbrt(&self)
     }
@@ -830,82 +871,102 @@ where
         Allocator<T, D> + Allocator<T, U1, D> + Allocator<T, D, U1> + Allocator<T, D, D>,
     <DefaultAllocator as Allocator<T, D>>::Buffer: Sync + Send,
 {
+    #[inline]
     fn copysign(self, _sign: Self) -> Self {
         todo!()
     }
 
+    #[inline]
     fn atan2(self, _other: Self) -> Self {
         todo!()
     }
 
+    #[inline]
     fn pi() -> Self {
         Self::from_re(std::f64::consts::PI.into())
     }
 
+    #[inline]
     fn two_pi() -> Self {
         Self::from_re(std::f64::consts::TAU.into())
     }
 
+    #[inline]
     fn frac_pi_2() -> Self {
         Self::from_re(std::f64::consts::FRAC_PI_4.into())
     }
 
+    #[inline]
     fn frac_pi_3() -> Self {
         Self::from_re(std::f64::consts::FRAC_PI_3.into())
     }
 
+    #[inline]
     fn frac_pi_4() -> Self {
         Self::from_re(std::f64::consts::FRAC_PI_4.into())
     }
 
+    #[inline]
     fn frac_pi_6() -> Self {
         Self::from_re(std::f64::consts::FRAC_PI_6.into())
     }
 
+    #[inline]
     fn frac_pi_8() -> Self {
         Self::from_re(std::f64::consts::FRAC_PI_8.into())
     }
 
+    #[inline]
     fn frac_1_pi() -> Self {
         Self::from_re(std::f64::consts::FRAC_1_PI.into())
     }
 
+    #[inline]
     fn frac_2_pi() -> Self {
         Self::from_re(std::f64::consts::FRAC_2_PI.into())
     }
 
+    #[inline]
     fn frac_2_sqrt_pi() -> Self {
         Self::from_re(std::f64::consts::FRAC_2_SQRT_PI.into())
     }
 
+    #[inline]
     fn e() -> Self {
         Self::from_re(std::f64::consts::E.into())
     }
 
+    #[inline]
     fn log2_e() -> Self {
         Self::from_re(std::f64::consts::LOG2_E.into())
     }
 
+    #[inline]
     fn log10_e() -> Self {
         Self::from_re(std::f64::consts::LOG10_E.into())
     }
 
+    #[inline]
     fn ln_2() -> Self {
         Self::from_re(std::f64::consts::LN_2.into())
     }
 
+    #[inline]
     fn ln_10() -> Self {
         Self::from_re(std::f64::consts::LN_10.into())
     }
 
+    #[inline]
     fn is_sign_positive(&self) -> bool {
         self.re.is_sign_positive()
     }
 
+    #[inline]
     fn is_sign_negative(&self) -> bool {
         self.re.is_sign_negative()
     }
 
+    #[inline]
     fn max(self, other: Self) -> Self {
         // Got to be careful using this, because you throw away the derivatives of the ones you
         // don't use.
@@ -916,6 +977,7 @@ where
         }
     }
 
+    #[inline]
     fn min(self, other: Self) -> Self {
         // Got to be careful using this, because you throw away the derivatives of one of them.
         if other < self {
@@ -925,6 +987,7 @@ where
         }
     }
 
+    #[inline]
     fn clamp(self, min: Self, max: Self) -> Self {
         // Got to be careful using this, because you throw away the derivatives of one of them.
         if self < min {
@@ -936,10 +999,12 @@ where
         }
     }
 
+    #[inline]
     fn min_value() -> Option<Self> {
         Some(Self::from_re(T::min_value()))
     }
 
+    #[inline]
     fn max_value() -> Option<Self> {
         Some(Self::from_re(T::max_value()))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 #![warn(clippy::all)]
 #![allow(clippy::needless_range_loop)]
 
-use num_traits::{Float, FromPrimitive, Inv, NumAssignOps, NumOps, Signed};
+use num_traits::{Float, FloatConst, FromPrimitive, Inv, NumAssignOps, NumOps, Signed};
 use std::fmt;
 use std::iter::{Product, Sum};
 
@@ -212,11 +212,11 @@ pub trait DualNum<F>:
 
 /// The underlying data type of individual derivatives. Usually f32 or f64.
 pub trait DualNumFloat:
-    Float + FromPrimitive + Signed + fmt::Display + fmt::Debug + Sync + Send + 'static
+    Float + FloatConst + FromPrimitive + Signed + fmt::Display + fmt::Debug + Sync + Send + 'static
 {
 }
 impl<T> DualNumFloat for T where
-    T: Float + FromPrimitive + Signed + fmt::Display + fmt::Debug + Sync + Send + 'static
+    T: Float + FloatConst + FromPrimitive + Signed + fmt::Display + fmt::Debug + Sync + Send + 'static
 {
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -557,66 +557,82 @@ macro_rules! impl_float_const {
             $($(DefaultAllocator: Allocator<T, $dim> + Allocator<T, U1, $dim> + Allocator<T, $dim, $dim>,)*
             DefaultAllocator: Allocator<T$(, $dim)*>)?
         {
+            #[allow(non_snake_case)]
             fn E() -> Self {
                 Self::from(F::E())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_1_PI() -> Self {
                 Self::from(F::FRAC_1_PI())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_1_SQRT_2() -> Self {
                 Self::from(F::FRAC_1_SQRT_2())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_2_PI() -> Self {
                 Self::from(F::FRAC_2_PI())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_2_SQRT_PI() -> Self {
                 Self::from(F::FRAC_2_SQRT_PI())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_PI_2() -> Self {
                 Self::from(F::FRAC_PI_2())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_PI_3() -> Self {
                 Self::from(F::FRAC_PI_3())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_PI_4() -> Self {
                 Self::from(F::FRAC_PI_4())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_PI_6() -> Self {
                 Self::from(F::FRAC_PI_6())
             }
 
+            #[allow(non_snake_case)]
             fn FRAC_PI_8() -> Self {
                 Self::from(F::FRAC_PI_8())
             }
 
+            #[allow(non_snake_case)]
             fn LN_10() -> Self {
                 Self::from(F::LN_10())
             }
 
+            #[allow(non_snake_case)]
             fn LN_2() -> Self {
                 Self::from(F::LN_2())
             }
 
+            #[allow(non_snake_case)]
             fn LOG10_E() -> Self {
                 Self::from(F::LOG10_E())
             }
 
+            #[allow(non_snake_case)]
             fn LOG2_E() -> Self {
                 Self::from(F::LOG2_E())
             }
 
+            #[allow(non_snake_case)]
             fn PI() -> Self {
                 Self::from(F::PI())
             }
 
+            #[allow(non_snake_case)]
             fn SQRT_2() -> Self {
                 Self::from(F::SQRT_2())
             }

--- a/tests/test_dual.rs
+++ b/tests/test_dual.rs
@@ -370,3 +370,53 @@ fn test_dual_bessel_j2_4() {
     assert!((res.re - -0.279979741339189).abs() < 1e-12);
     assert!((res.eps.unwrap() - -0.132099570594364).abs() < 1e-12);
 }
+
+mod nalgebra_api {
+    use nalgebra::{Point2, Point3, UnitQuaternion, Vector2, Vector3};
+    use num_dual::*;
+    use num_traits::Zero;
+    use std::f32::consts::*;
+
+    fn unit_circle(t: Dual32) -> Point2<Dual32> {
+        let x_dir = |x: Dual32| Vector2::new(x, Dual32::zero());
+        let y_dir = |y: Dual32| Vector2::new(Dual32::zero(), y);
+        let theta = t * TAU;
+        Point2::from(x_dir(theta.cos()) + y_dir(theta.sin()))
+    }
+
+    // This is testing that you can type-check code that whacks DualVec in
+    // nalgebra structures and tries to use them.
+    #[test]
+    fn use_nalgebra_2d() {
+        // 1 radian around the circle
+        let t = Dual32::from_re(0.25).derivative();
+        let point = unit_circle(t);
+        let real = point.map(|x| x.re);
+        let grad = point.map(|x| x.eps.unwrap());
+        println!("point: {}", point.coords);
+        approx::assert_relative_eq!(real, Point2::new(0., 1.), epsilon = 1e-3);
+        approx::assert_relative_eq!(grad, Point2::new(-TAU, 0.), epsilon = 1e-3);
+    }
+
+    #[test]
+    fn use_nalgebra_3d() {
+        // First one does nothing to the gradient. Still got no y or z direction.
+        let rot1 = UnitQuaternion::from_axis_angle(&Vector3::x_axis(), FRAC_PI_8);
+        // Second one goes pi/8 (22.5deg) about the y axis, which should shift some of the steepness
+        // in the x direction into the z direction, but not much.
+        let rot2 = UnitQuaternion::from_axis_angle(&Vector3::y_axis(), FRAC_PI_8);
+        let rotation = (rot2 * rot1).cast::<Dual32>();
+        let lifted_3d_circle = |t: Dual32| {
+            let xy = unit_circle(t); // [0, 1] with derivatives [-1, 0]
+            Point3::new(xy.x, xy.y, Dual32::zero())
+        };
+        let function = |t: Dual32| rotation * lifted_3d_circle(t);
+        let point = function(Dual32::from_re(0.25).derivative());
+        let real = point.map(|x| x.re);
+        let grad = point.map(|x| x.eps.unwrap());
+        println!("rotated point: {}", point.coords);
+        approx::assert_relative_eq!(real.coords, real.coords.normalize(), epsilon = 1e-3);
+        approx::assert_relative_eq!(real, Point3::new(0.146, 0.924, 0.354), epsilon = 1e-3);
+        approx::assert_relative_eq!(grad, Point3::new(-5.805, 0., 2.404), epsilon = 1e-3);
+    }
+}

--- a/tests/test_dual_vec.rs
+++ b/tests/test_dual_vec.rs
@@ -1,4 +1,4 @@
-use nalgebra::*;
+use nalgebra::{Const, Vector};
 use num_dual::*;
 
 #[test]

--- a/tests/test_dual_vec.rs
+++ b/tests/test_dual_vec.rs
@@ -1,4 +1,4 @@
-use nalgebra::{Const, Vector};
+use nalgebra::*;
 use num_dual::*;
 
 #[test]


### PR DESCRIPTION
Does what it says on the tin. Partially addresses #55 

- Only implemented for DualVec, not the more complicated ones
- But this impl should serve pretty well as a model for the other types
- I am not 100% sure of the RealField and ComplexField impls. Can someone go over these and see if they make sense for dual numbers?
- Missing atan2 and copysign, panics instead, wasn't sure what to do about those. Is there a reference implementation of atan2 on duals?
- Bonus: prettier Display implementation like `0.35355338 + 2.404471ε`

The Simd-enabled part turned out to be useless for now, see https://github.com/dimforge/simba/issues/44. It was pretty easy to implement SimdValue and thus we are able to split a `DualVec<simba::simd::f32x4, f32, 1>` into four `DualVec<f32, f32, 1>`, and join them back together. So we can get in and out of SIMD-land.

Alas, we are not able to implement SimdRealField/SimdComplexField directly and thus use T's vectorized operations. So we are stuck with implementing the non-vectorized `RealField`/`ComplexField` for now. If that problem is fixed, we'll be able to swap out that with the Simd version of the trait, using basically find/replace `fn ` with `fn simd_` or thereabouts.