### PR TITLE
Deprecate linalg module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,10 @@ pub use hyperhyperdual::{
 };
 
 #[cfg(feature = "linalg")]
+#[deprecated(
+    since = "0.7.0",
+    note = "please use methods from `nalgebra` or other linear algebra libraries instead"
+)]
 pub mod linalg;
 
 #[cfg(feature = "python")]
@@ -216,7 +220,15 @@ pub trait DualNumFloat:
 {
 }
 impl<T> DualNumFloat for T where
-    T: Float + FloatConst + FromPrimitive + Signed + fmt::Display + fmt::Debug + Sync + Send + 'static
+    T: Float
+        + FloatConst
+        + FromPrimitive
+        + Signed
+        + fmt::Display
+        + fmt::Debug
+        + Sync
+        + Send
+        + 'static
 {
 }
 


### PR DESCRIPTION
Closes #55 

With #59 linear algebra methods from `nalgebra` can be used with dual numbers. As suggested in #62, this should be extended to other number types in the future.

In the meantime, downstream crates should start moving away from the linear algebra methods implemented in this crate to better maintained implementations in other crates.