### PR TITLE
Add serialization and deserialization with serde for scalar dual numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.9.1] - 2024-04-15
 ### Added
 - Added `serde` feature that enables serialization and deserialization of all scalar dual numbers. [#74](https://github.com/itt-ustutt/num-dual/pull/74)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `serde` feature that enables serialization and deserialization of all scalar dual numbers. [#74](https://github.com/itt-ustutt/num-dual/pull/74)
 
 ## [0.9.0] - 2024-04-11
 ### Packaging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ndarray = { version = "0.15", optional = true }
 numpy = { version = "0.21", optional = true }
 approx = "0.5"
 simba = "0.8"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [profile.release]
 lto = true
@@ -36,6 +37,7 @@ linalg = ["ndarray"]
 
 [dev-dependencies]
 criterion = "0.5"
+serde_json = "1.0"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num-dual"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Gernot Bauer <bauer@itt.uni-stuttgart.de>",
            "Philipp Rehner <prehner@ethz.ch>"]
 edition = "2021"

--- a/src/dual.rs
+++ b/src/dual.rs
@@ -2,6 +2,8 @@ use crate::{DualNum, DualNumFloat};
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use nalgebra::*;
 use num_traits::{Float, FloatConst, FromPrimitive, Inv, Num, One, Signed, Zero};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::fmt;
 use std::iter::{Product, Sum};
@@ -12,11 +14,13 @@ use std::ops::{
 
 /// A scalar dual number for the calculations of first derivatives.
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Dual<T: DualNum<F>, F> {
     /// Real part of the dual number
     pub re: T,
     /// Derivative part of the dual number
     pub eps: T,
+    #[cfg_attr(feature = "serde", serde(skip))]
     f: PhantomData<F>,
 }
 

--- a/src/dual2.rs
+++ b/src/dual2.rs
@@ -1,5 +1,7 @@
 use crate::{DualNum, DualNumFloat};
 use num_traits::{Float, FloatConst, FromPrimitive, Inv, Num, One, Signed, Zero};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::fmt;
 use std::iter::{Product, Sum};
@@ -10,6 +12,7 @@ use std::ops::{
 
 /// A scalar second order dual number for the calculation of second derivatives.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Dual2<T: DualNum<F>, F> {
     /// Real part of the second order dual number
     pub re: T,
@@ -17,6 +20,7 @@ pub struct Dual2<T: DualNum<F>, F> {
     pub v1: T,
     /// Second derivative part of the second order dual number
     pub v2: T,
+    #[cfg_attr(feature = "serde", serde(skip))]
     f: PhantomData<F>,
 }
 

--- a/src/dual3.rs
+++ b/src/dual3.rs
@@ -1,5 +1,7 @@
 use crate::{DualNum, DualNumFloat};
 use num_traits::{Float, FloatConst, FromPrimitive, Inv, Num, One, Signed, Zero};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::fmt;
 use std::iter::{Product, Sum};
@@ -8,6 +10,7 @@ use std::ops::*;
 
 /// A scalar third order dual number for the calculation of third derivatives.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Dual3<T, F = T> {
     /// Real part of the third order dual number
     pub re: T,
@@ -17,6 +20,7 @@ pub struct Dual3<T, F = T> {
     pub v2: T,
     /// Third derivative part of the third order dual number
     pub v3: T,
+    #[cfg_attr(feature = "serde", serde(skip))]
     f: PhantomData<F>,
 }
 

--- a/src/hyperdual.rs
+++ b/src/hyperdual.rs
@@ -1,5 +1,7 @@
 use crate::{DualNum, DualNumFloat};
 use num_traits::{Float, FloatConst, FromPrimitive, Inv, Num, One, Signed, Zero};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::fmt;
 use std::iter::{Product, Sum};
@@ -10,6 +12,7 @@ use std::ops::{
 
 /// A scalar hyper-dual number for the calculation of second partial derivatives.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HyperDual<T: DualNum<F>, F> {
     /// Real part of the hyper-dual number
     pub re: T,
@@ -19,6 +22,7 @@ pub struct HyperDual<T: DualNum<F>, F> {
     pub eps2: T,
     /// Second partial derivative part of the hyper-dual number
     pub eps1eps2: T,
+    #[cfg_attr(feature = "serde", serde(skip))]
     f: PhantomData<F>,
 }
 

--- a/src/hyperhyperdual.rs
+++ b/src/hyperhyperdual.rs
@@ -1,5 +1,7 @@
 use crate::{DualNum, DualNumFloat};
 use num_traits::{Float, FloatConst, FromPrimitive, Inv, Num, One, Signed, Zero};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::fmt;
 use std::iter::{Product, Sum};
@@ -8,6 +10,7 @@ use std::ops::*;
 
 /// A scalar hyper-hyper-dual number for the calculation of third partial derivatives.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HyperHyperDual<T, F = T> {
     /// Real part of the hyper-hyper-dual number
     pub re: T,
@@ -25,6 +28,7 @@ pub struct HyperHyperDual<T, F = T> {
     pub eps2eps3: T,
     /// Third partial derivative part of the hyper-hyper-dual number
     pub eps1eps2eps3: T,
+    #[cfg_attr(feature = "serde", serde(skip))]
     f: PhantomData<F>,
 }
 

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "serde")]
+use num_dual::*;
+use serde_json::Error;
+
+#[test]
+fn test_serde_dual() -> Result<(), Error> {
+    let x = Dual::from_re(2.0).derivative();
+    let s = serde_json::to_string(&x)?;
+    println!("{s}");
+    let y: Dual64 = serde_json::from_str(&s)?;
+    println!("{y}");
+    assert_eq!(x, y);
+    Ok(())
+}
+
+#[test]
+fn test_serde_dual2() -> Result<(), Error> {
+    let x = Dual2::from_re(2.0).derivative();
+    let s = serde_json::to_string(&x)?;
+    println!("{s}");
+    let y: Dual2_64 = serde_json::from_str(&s)?;
+    println!("{y}");
+    assert_eq!(x, y);
+    Ok(())
+}
+
+#[test]
+fn test_serde_dual3() -> Result<(), Error> {
+    let x = Dual3::from_re(2.0).derivative();
+    let s = serde_json::to_string(&x)?;
+    println!("{s}");
+    let y: Dual3_64 = serde_json::from_str(&s)?;
+    println!("{y}");
+    assert_eq!(x, y);
+    Ok(())
+}
+
+#[test]
+fn test_serde_hyperdual() -> Result<(), Error> {
+    let x = HyperDual::from_re(2.0).derivative1().derivative2();
+    let s = serde_json::to_string(&x)?;
+    println!("{s}");
+    let y: HyperDual64 = serde_json::from_str(&s)?;
+    println!("{y}");
+    assert_eq!(x, y);
+    Ok(())
+}
+
+#[test]
+fn test_serde_hyperhyperdual() -> Result<(), Error> {
+    let x = HyperHyperDual::from_re(2.0)
+        .derivative1()
+        .derivative2()
+        .derivative3();
+    let s = serde_json::to_string(&x)?;
+    println!("{s}");
+    let y: HyperHyperDual64 = serde_json::from_str(&s)?;
+    println!("{y}");
+    assert_eq!(x, y);
+    Ok(())
+}


### PR DESCRIPTION
`nalgebra` has a serde feature, but for generic vectors (static or dynamic) additional trait bounds on some associated types would be required.

@g-bauer I used a feature flag for the serde dependency. Do you think the additional boilerplate is worth it for a more ergonomic library for non serde users?