### PR TITLE
Expose mutable reference to real part of a dual number

### DIFF
--- a/src/derivatives.rs
+++ b/src/derivatives.rs
@@ -21,6 +21,11 @@ macro_rules! impl_derivatives {
             }
 
             #[inline]
+            fn re_mut(&mut self) -> &mut F {
+                self.re.re_mut()
+            }
+
+            #[inline]
             fn recip(&self) -> Self {
                 let rec = self.re.recip();
                 let f0 = rec.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,9 @@ pub trait DualNum<F>:
     /// Real part (0th derivative) of the number
     fn re(&self) -> F;
 
+    /// Mutable reference to real part (0th derivative) of the number
+    fn re_mut(&mut self) -> &mut F;
+
     /// Reciprocal (inverse) of a number `1/x`
     fn recip(&self) -> Self;
 
@@ -260,6 +263,10 @@ macro_rules! impl_dual_num_float {
 
             fn re(&self) -> $float {
                 *self
+            }
+
+            fn re_mut(&mut self) -> &mut $float {
+                self
             }
 
             fn mul_add(&self, a: Self, b: Self) -> Self {


### PR DESCRIPTION
It is useful when normalizing periodic variables (i.e. angles).