### PR TITLE
Simple to use interface for implicit equations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2025-06-24
+### Changed
+- Changed the implicit function interface to deal more straightforwardly with complex function arguments. [#94](https://github.com/itt-ustutt/num-dual/pull/94)
+
 ## [0.11.1] - 2025-04-09
-## Added
+### Added
 - Added the functions `implicit_derivative`, `implicit_derivative_unary`, and `implicit_derivative_binary` for the convenient calculation of arbitrary derivatives of implicit functions. [#91](https://github.com/itt-ustutt/num-dual/pull/91)
 
 ## [0.11.0] - 2024-12-05
-## Packaging
+### Packaging
 - Updated `pyo3` and `numpy` dependencies to 0.23. [#88](https://github.com/itt-ustutt/num-dual/pull/88)
 
 ## [0.10.3] - 2024-11-14
-## Added
+### Added
 - Added nalgebra compatibility for `Dual2` and `Dual2Vec`. [#81](https://github.com/itt-ustutt/num-dual/pull/81)
 - Added `atan2` to the `DualNum` trait. [#85](https://github.com/itt-ustutt/num-dual/pull/85)
 
 ## [0.10.2] - 2024-11-06
-## Changed
+### Changed
 - Exposed macros for the implementation of the `DualNum` trait publicly. [#83](https://github.com/itt-ustutt/num-dual/pull/83)
 
 ## [0.10.1] - 2024-11-05
-## Added
+### Added
 - Expose the inner type of a generalized (hyper) dual number in the `DualNum` trait. [#82](https://github.com/itt-ustutt/num-dual/pull/82)
 
 ## [0.10.0] - 2024-10-22

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num-dual"
-version = "0.11.1"
+version = "0.11.2"
 authors = [
     "Gernot Bauer <bauer@itt.uni-stuttgart.de>",
     "Philipp Rehner <prehner@ethz.ch>",
@@ -23,15 +23,15 @@ name = "num_dual"
 num-traits = "0.2"
 nalgebra = "0.33"
 ndarray = { version = "0.16", optional = true }
-numpy = { version = "0.23", optional = true }
+numpy = { version = "0.25", optional = true }
 approx = "0.5"
 simba = "0.9"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dependencies.pyo3]
-version = "0.23"
+version = "0.25"
 optional = true
-features = ["multiple-pymethods", "extension-module", "abi3", "abi3-py37"]
+features = ["multiple-pymethods", "extension-module", "abi3", "abi3-py39"]
 
 [profile.release]
 lto = true

--- a/src/dual_vec.rs
+++ b/src/dual_vec.rs
@@ -26,6 +26,7 @@ where
 
 impl<T: DualNum<F> + Copy, F: Copy, const N: usize> Copy for DualVec<T, F, Const<N>> {}
 
+pub type DualSVec<D, F, const N: usize> = DualVec<D, F, Const<N>>;
 pub type DualVec32<D> = DualVec<f32, f32, D>;
 pub type DualVec64<D> = DualVec<f64, f64, D>;
 pub type DualSVec32<const N: usize> = DualVec<f32, f32, Const<N>>;
@@ -139,8 +140,7 @@ pub fn jacobian<G, T: DualNum<F>, F: DualNumFloat, M: Dim, N: Dim>(
 ) -> (OVector<T, M>, OMatrix<T, M, N>)
 where
     G: FnOnce(OVector<DualVec<T, F, N>, N>) -> OVector<DualVec<T, F, N>, M>,
-    DefaultAllocator:
-        Allocator<M> + Allocator<N> + Allocator<M, N> + Allocator<nalgebra::Const<1>, N>,
+    DefaultAllocator: Allocator<M> + Allocator<N> + Allocator<M, N> + Allocator<U1, N>,
 {
     try_jacobian(|x| Ok::<_, Infallible>(g(x)), x).unwrap()
 }
@@ -153,8 +153,7 @@ pub fn try_jacobian<G, T: DualNum<F>, F: DualNumFloat, E, M: Dim, N: Dim>(
 ) -> Result<(OVector<T, M>, OMatrix<T, M, N>), E>
 where
     G: FnOnce(OVector<DualVec<T, F, N>, N>) -> Result<OVector<DualVec<T, F, N>, M>, E>,
-    DefaultAllocator:
-        Allocator<M> + Allocator<N> + Allocator<M, N> + Allocator<nalgebra::Const<1>, N>,
+    DefaultAllocator: Allocator<M> + Allocator<N> + Allocator<M, N> + Allocator<U1, N>,
 {
     let mut x = x.map(DualVec::from_re);
     let (r, c) = x.shape_generic();

--- a/src/implicit.rs
+++ b/src/implicit.rs
@@ -1,6 +1,6 @@
-use crate::{first_derivative, jacobian, Dual, DualNum, DualNumFloat, DualVec};
+use crate::{first_derivative, jacobian, Dual, DualNum, DualNumFloat, DualSVec, DualVec};
 use nalgebra::allocator::Allocator;
-use nalgebra::{Const, DefaultAllocator, Dim, OMatrix, OVector, SVector, U1};
+use nalgebra::{DefaultAllocator, Dim, OMatrix, OVector, SVector, Scalar, U1, U2};
 use num_traits::Float;
 use std::collections::HashMap;
 use std::fmt;
@@ -10,15 +10,15 @@ use std::marker::PhantomData;
 /// Calculate the derivative of the unary implicit function
 ///         g(x, args) = 0
 /// ```
-/// # use num_dual::{implicit_derivative_unary, DualNum, Dual2_64};
+/// # use num_dual::{implicit_derivative, DualNum, Dual2_64};
 /// # use approx::assert_relative_eq;
 /// let y = Dual2_64::from(25.0).derivative();
-/// let x = implicit_derivative_unary(|x,y| x.powi(2)-y, 5.0f64, &y);
+/// let x = implicit_derivative(|x,y| x.powi(2)-y, 5.0f64, &y);
 /// assert_relative_eq!(x.re, y.sqrt().re, max_relative=1e-16);
 /// assert_relative_eq!(x.v1, y.sqrt().v1, max_relative=1e-16);
 /// assert_relative_eq!(x.v2, y.sqrt().v2, max_relative=1e-16);
 /// ```
-pub fn implicit_derivative_unary<G, D: DualNum<F>, F: DualNumFloat, A: Lift<D, F>>(
+pub fn implicit_derivative<G, D: DualNum<F>, F: DualNumFloat, A: DualStruct<D, F>>(
     g: G,
     x: F,
     args: &A,
@@ -48,7 +48,7 @@ where
 /// assert_relative_eq!(y.re, a.re, max_relative = 1e-16);
 /// assert_relative_eq!(y.eps, a.eps, max_relative = 1e-16);
 /// ```
-pub fn implicit_derivative_binary<G, D: DualNum<F>, F: DualNumFloat, A: Lift<D, F>>(
+pub fn implicit_derivative_binary<G, D: DualNum<F>, F: DualNumFloat, A: DualStruct<D, F>>(
     g: G,
     x: F,
     y: F,
@@ -56,10 +56,10 @@ pub fn implicit_derivative_binary<G, D: DualNum<F>, F: DualNumFloat, A: Lift<D, 
 ) -> [D; 2]
 where
     G: Fn(
-        DualVec<D, F, Const<2>>,
-        DualVec<D, F, Const<2>>,
-        &A::Lifted<DualVec<D, F, Const<2>>>,
-    ) -> [DualVec<D, F, Const<2>>; 2],
+        DualVec<D, F, U2>,
+        DualVec<D, F, U2>,
+        &A::Lifted<DualVec<D, F, U2>>,
+    ) -> [DualVec<D, F, U2>; 2],
 {
     let mut x = D::from(x);
     let mut y = D::from(y);
@@ -73,7 +73,7 @@ where
             SVector::from([x.clone(), y.clone()]),
         );
         let [[f0, f1]] = f.data.0;
-        let [[j00, j01], [j10, j11]] = jac.data.0;
+        let [[j00, j10], [j01, j11]] = jac.data.0;
         let det = (j00.clone() * &j11 - j01.clone() * &j10).recip();
         x -= (j11 * &f0 - j01 * &f1) * &det;
         y -= (j00 * &f1 - j10 * &f0) * &det;
@@ -84,11 +84,11 @@ where
 /// Calculate the derivative of the multivariate implicit function
 ///         g(x, args) = 0
 /// ```
-/// # use num_dual::{implicit_derivative, Dual64};
+/// # use num_dual::{implicit_derivative_vec, Dual64};
 /// # use approx::assert_relative_eq;
 /// # use nalgebra::SVector;
 /// let a = Dual64::from(4.0).derivative();
-/// let x = implicit_derivative(
+/// let x = implicit_derivative_vec(
 ///     |x, a| SVector::from([x[0] * x[1] - a, x[0] + x[1] - a - 1.0]),
 ///     SVector::from([1.0f64, 4.0f64]),
 ///     &a,
@@ -98,7 +98,13 @@ where
 /// assert_relative_eq!(x[1].re, a.re, max_relative = 1e-16);
 /// assert_relative_eq!(x[1].eps, a.eps, max_relative = 1e-16);
 /// ```
-pub fn implicit_derivative<G, D: DualNum<F> + Copy, F: DualNumFloat, A: Lift<D, F>, N: Dim>(
+pub fn implicit_derivative_vec<
+    G,
+    D: DualNum<F> + Copy,
+    F: DualNumFloat,
+    A: DualStruct<D, F>,
+    N: Dim,
+>(
     g: G,
     x: OVector<F, N>,
     args: &A,
@@ -119,64 +125,207 @@ where
     x
 }
 
-pub trait Lift<D, F> {
+/// An implicit function g(x, args) = 0 for which derivatives of x can be
+/// calculated with the [ImplicitDerivative] struct.
+pub trait ImplicitFunction<F> {
+    /// data type of the parameter struct, needs to implement [DualStruct].
+    type Parameters<D: DualNum<F>>: DualStruct<D, F>;
+
+    /// data type of the variable `x`, needs to be either `D`, `[D; 2]`, or `SVector<D, N>`.
+    type Variable<D>;
+
+    /// implementation of the residual function g(x, args) = 0.
+    fn residual<D: DualNum<F> + Copy>(
+        parameters: &Self::Parameters<D>,
+        x: Self::Variable<D>,
+    ) -> Self::Variable<D>;
+}
+
+/// Helper struct that stores parameters in dual and real form and provides functions
+/// for evaluating real residuals (for external solvers) and implicit derivatives for
+/// arbitrary dual numbers.
+pub struct ImplicitDerivative<G: ImplicitFunction<F>, D: DualNum<F>, F: DualNum<F>> {
+    base: G::Parameters<F>,
+    derivative: G::Parameters<D>,
+}
+
+impl<G: ImplicitFunction<F>, D: DualNum<F> + Copy, F: DualNum<F> + DualNumFloat>
+    ImplicitDerivative<G, D, F>
+where
+    G::Parameters<D>: DualStruct<D, F, Real = G::Parameters<F>>,
+{
+    pub fn new(_: G, parameters: G::Parameters<D>) -> Self {
+        Self {
+            base: parameters.real(),
+            derivative: parameters,
+        }
+    }
+
+    /// Evaluate the (real) residual for a scalar function.
+    pub fn residual(&self, x: F) -> F
+    where
+        G: ImplicitFunction<F, Variable<F> = F>,
+    {
+        G::residual(&self.base, x)
+    }
+
+    /// Evaluate the (real) residual for a bivariate function.
+    pub fn residual_binary(&self, x: F, y: F) -> [F; 2]
+    where
+        G: ImplicitFunction<F, Variable<F> = [F; 2]>,
+    {
+        G::residual(&self.base, [x, y])
+    }
+
+    /// Evaluate the (real) residual for a multivariate function.
+    pub fn residual_vec<N: Dim>(&self, x: OVector<F, N>) -> OVector<F, N>
+    where
+        DefaultAllocator: Allocator<N>,
+        G: ImplicitFunction<F, Variable<F> = OVector<F, N>>,
+    {
+        G::residual(&self.base, x)
+    }
+
+    /// Evaluate the implicit derivative for a scalar function.
+    pub fn implicit_derivative(&self, x: F) -> D
+    where
+        G: ImplicitFunction<F, Variable<Dual<D, F>> = Dual<D, F>>,
+        G::Parameters<D>: DualStruct<D, F, Lifted<Dual<D, F>> = G::Parameters<Dual<D, F>>>,
+    {
+        implicit_derivative(|x, args| G::residual(args, x), x, &self.derivative)
+    }
+
+    /// Evaluate the implicit derivative for a bivariate function.
+    pub fn implicit_derivative_binary(&self, x: F, y: F) -> [D; 2]
+    where
+        G: ImplicitFunction<F, Variable<DualVec<D, F, U2>> = [DualVec<D, F, U2>; 2]>,
+        G::Parameters<D>:
+            DualStruct<D, F, Lifted<DualVec<D, F, U2>> = G::Parameters<DualVec<D, F, U2>>>,
+    {
+        implicit_derivative_binary(
+            |x, y, args| G::residual(args, [x, y]),
+            x,
+            y,
+            &self.derivative,
+        )
+    }
+
+    /// Evaluate the implicit derivative for a multivariate function.
+    pub fn implicit_derivative_vec<const N: usize>(&self, x: SVector<F, N>) -> SVector<D, N>
+    where
+        G: ImplicitFunction<F, Variable<DualSVec<D, F, N>> = SVector<DualSVec<D, F, N>, N>>,
+        G::Parameters<D>:
+            DualStruct<D, F, Lifted<DualSVec<D, F, N>> = G::Parameters<DualSVec<D, F, N>>>,
+    {
+        implicit_derivative_vec(|x, args| G::residual(args, x), x, &self.derivative)
+    }
+}
+
+/// A struct that contains dual numbers. Needed for arbitrary arguments in [ImplicitFunction].
+///
+/// The trait is implemented for all dual types themselves, and common data types (tuple, vec,
+/// array, ...) and can be implemented for custom data types to achieve full flexibility.
+pub trait DualStruct<D, F> {
+    type Real;
     type Lifted<D2: DualNum<F, Inner = D>>;
+    fn real(&self) -> Self::Real;
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2>;
 }
 
-impl<D, F> Lift<D, F> for () {
+impl<D, F> DualStruct<D, F> for () {
+    type Real = ();
     type Lifted<D2: DualNum<F, Inner = D>> = ();
+    fn real(&self) {}
     fn lift<D2: DualNum<F, Inner = D>>(&self) {}
 }
 
-impl Lift<f32, f32> for f32 {
+impl DualStruct<f32, f32> for f32 {
+    type Real = f32;
     type Lifted<D: DualNum<f32, Inner = f32>> = D;
+    fn real(&self) -> f32 {
+        *self
+    }
     fn lift<D: DualNum<f32, Inner = f32>>(&self) -> D {
         D::from_inner(*self)
     }
 }
 
-impl Lift<f64, f64> for f64 {
+impl DualStruct<f64, f64> for f64 {
+    type Real = f64;
     type Lifted<D: DualNum<f64, Inner = f64>> = D;
+    fn real(&self) -> f64 {
+        *self
+    }
     fn lift<D: DualNum<f64, Inner = f64>>(&self) -> D {
         D::from_inner(*self)
     }
 }
 
-impl<D, F, T1: Lift<D, F>, T2: Lift<D, F>> Lift<D, F> for (T1, T2) {
+impl<D, F, T1: DualStruct<D, F>, T2: DualStruct<D, F>> DualStruct<D, F> for (T1, T2) {
+    type Real = (T1::Real, T2::Real);
     type Lifted<D2: DualNum<F, Inner = D>> = (T1::Lifted<D2>, T2::Lifted<D2>);
+    fn real(&self) -> Self::Real {
+        let (s1, s2) = self;
+        (s1.real(), s2.real())
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         let (s1, s2) = self;
         (s1.lift(), s2.lift())
     }
 }
 
-impl<D, F, T1: Lift<D, F>, T2: Lift<D, F>, T3: Lift<D, F>> Lift<D, F> for (T1, T2, T3) {
+impl<D, F, T1: DualStruct<D, F>, T2: DualStruct<D, F>, T3: DualStruct<D, F>> DualStruct<D, F>
+    for (T1, T2, T3)
+{
+    type Real = (T1::Real, T2::Real, T3::Real);
     type Lifted<D2: DualNum<F, Inner = D>> = (T1::Lifted<D2>, T2::Lifted<D2>, T3::Lifted<D2>);
+    fn real(&self) -> Self::Real {
+        let (s1, s2, s3) = self;
+        (s1.real(), s2.real(), s3.real())
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         let (s1, s2, s3) = self;
         (s1.lift(), s2.lift(), s3.lift())
     }
 }
 
-impl<D, F, T1: Lift<D, F>, T2: Lift<D, F>, T3: Lift<D, F>, T4: Lift<D, F>> Lift<D, F>
-    for (T1, T2, T3, T4)
+impl<
+        D,
+        F,
+        T1: DualStruct<D, F>,
+        T2: DualStruct<D, F>,
+        T3: DualStruct<D, F>,
+        T4: DualStruct<D, F>,
+    > DualStruct<D, F> for (T1, T2, T3, T4)
 {
+    type Real = (T1::Real, T2::Real, T3::Real, T4::Real);
     type Lifted<D2: DualNum<F, Inner = D>> = (
         T1::Lifted<D2>,
         T2::Lifted<D2>,
         T3::Lifted<D2>,
         T4::Lifted<D2>,
     );
+    fn real(&self) -> Self::Real {
+        let (s1, s2, s3, s4) = self;
+        (s1.real(), s2.real(), s3.real(), s4.real())
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         let (s1, s2, s3, s4) = self;
         (s1.lift(), s2.lift(), s3.lift(), s4.lift())
     }
 }
 
-impl<D, F, T1: Lift<D, F>, T2: Lift<D, F>, T3: Lift<D, F>, T4: Lift<D, F>, T5: Lift<D, F>>
-    Lift<D, F> for (T1, T2, T3, T4, T5)
+impl<
+        D,
+        F,
+        T1: DualStruct<D, F>,
+        T2: DualStruct<D, F>,
+        T3: DualStruct<D, F>,
+        T4: DualStruct<D, F>,
+        T5: DualStruct<D, F>,
+    > DualStruct<D, F> for (T1, T2, T3, T4, T5)
 {
+    type Real = (T1::Real, T2::Real, T3::Real, T4::Real, T5::Real);
     type Lifted<D2: DualNum<F, Inner = D>> = (
         T1::Lifted<D2>,
         T2::Lifted<D2>,
@@ -184,38 +333,58 @@ impl<D, F, T1: Lift<D, F>, T2: Lift<D, F>, T3: Lift<D, F>, T4: Lift<D, F>, T5: L
         T4::Lifted<D2>,
         T5::Lifted<D2>,
     );
+    fn real(&self) -> Self::Real {
+        let (s1, s2, s3, s4, s5) = self;
+        (s1.real(), s2.real(), s3.real(), s4.real(), s5.real())
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         let (s1, s2, s3, s4, s5) = self;
         (s1.lift(), s2.lift(), s3.lift(), s4.lift(), s5.lift())
     }
 }
 
-impl<D, F, T: Lift<D, F>, const N: usize> Lift<D, F> for [T; N] {
+impl<D, F, T: DualStruct<D, F>, const N: usize> DualStruct<D, F> for [T; N] {
+    type Real = [T::Real; N];
     type Lifted<D2: DualNum<F, Inner = D>> = [T::Lifted<D2>; N];
+    fn real(&self) -> Self::Real {
+        self.each_ref().map(|x| x.real())
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         self.each_ref().map(|x| x.lift())
     }
 }
 
-impl<D, F, T: Lift<D, F>> Lift<D, F> for Vec<T> {
+impl<D, F, T: DualStruct<D, F>> DualStruct<D, F> for Vec<T> {
+    type Real = Vec<T::Real>;
     type Lifted<D2: DualNum<F, Inner = D>> = Vec<T::Lifted<D2>>;
+    fn real(&self) -> Self::Real {
+        self.iter().map(|x| x.real()).collect()
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         self.iter().map(|x| x.lift()).collect()
     }
 }
 
-impl<D, F, T: Lift<D, F>, K: Clone + Eq + Hash> Lift<D, F> for HashMap<K, T> {
+impl<D, F, T: DualStruct<D, F>, K: Clone + Eq + Hash> DualStruct<D, F> for HashMap<K, T> {
+    type Real = HashMap<K, T::Real>;
     type Lifted<D2: DualNum<F, Inner = D>> = HashMap<K, T::Lifted<D2>>;
+    fn real(&self) -> Self::Real {
+        self.iter().map(|(k, x)| (k.clone(), x.real())).collect()
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         self.iter().map(|(k, x)| (k.clone(), x.lift())).collect()
     }
 }
 
-impl<D: DualNum<F>, F, R: Dim, C: Dim> Lift<D, F> for OMatrix<D, R, C>
+impl<D: DualNum<F>, F: Scalar, R: Dim, C: Dim> DualStruct<D, F> for OMatrix<D, R, C>
 where
     DefaultAllocator: Allocator<R, C>,
 {
+    type Real = OMatrix<F, R, C>;
     type Lifted<D2: DualNum<F, Inner = D>> = OMatrix<D2, R, C>;
+    fn real(&self) -> Self::Real {
+        self.map(|x| x.re())
+    }
     fn lift<D2: DualNum<F, Inner = D>>(&self) -> Self::Lifted<D2> {
         self.map(|x| D2::from_inner(x))
     }
@@ -346,5 +515,77 @@ mod test {
         let lu = LU::new(a).unwrap();
         let x = lu.solve(&b);
         assert_eq!((x[0].re, x[0].eps, x[1].re, x[1].eps), (1.0, 2.0, 2.0, 1.0));
+    }
+
+    struct TestFunction;
+    impl ImplicitFunction<f64> for TestFunction {
+        type Parameters<D: DualNum<f64>> = D;
+        type Variable<D> = D;
+
+        fn residual<D: DualNum<f64> + Copy>(square: &D, x: D) -> D {
+            *square - x * x
+        }
+    }
+
+    struct TestFunction2;
+    impl ImplicitFunction<f64> for TestFunction2 {
+        type Parameters<D: DualNum<f64>> = (D, D);
+        type Variable<D> = [D; 2];
+
+        fn residual<D: DualNum<f64> + Copy>((square_sum, sum): &(D, D), [x, y]: [D; 2]) -> [D; 2] {
+            [*square_sum - x * x - y * y, *sum - x - y]
+        }
+    }
+
+    struct TestFunction3<const N: usize>;
+    impl<const N: usize> ImplicitFunction<f64> for TestFunction3<N> {
+        type Parameters<D: DualNum<f64>> = D;
+        type Variable<D> = SVector<D, N>;
+
+        fn residual<D: DualNum<f64> + Copy>(&square_sum: &D, x: SVector<D, N>) -> SVector<D, N> {
+            let mut res = x;
+            for i in 1..N {
+                res[i] = x[i] - x[i - 1] - D::from(1.0);
+            }
+            res[0] = square_sum - x.dot(&x);
+            res
+        }
+    }
+
+    #[test]
+    fn test() {
+        let f: crate::Dual64 = Dual::from(25.0).derivative();
+        let func = ImplicitDerivative::new(TestFunction, f);
+        println!("{}", func.residual(5.0));
+        println!("{}", func.implicit_derivative(5.0));
+        println!("{}", f.sqrt());
+        assert_eq!(f.sqrt(), func.implicit_derivative(5.0));
+
+        let a: crate::Dual64 = Dual::from(25.0).derivative();
+        let b: crate::Dual64 = Dual::from(7.0);
+        let func = ImplicitDerivative::new(TestFunction2, (a, b));
+        println!("\n{:?}", func.residual_binary(4.0, 3.0));
+        let [x, y] = func.implicit_derivative_binary(4.0, 3.0);
+        let xa = (b + (a * 2.0 - b * b).sqrt()) * 0.5;
+        let ya = (b - (a * 2.0 - b * b).sqrt()) * 0.5;
+        println!("{x}, {y}");
+        println!("{}, {}", xa, ya);
+        assert_eq!(x, xa);
+        assert_eq!(y, ya);
+
+        let s: crate::Dual64 = Dual::from(30.0).derivative();
+        let func = ImplicitDerivative::new(TestFunction3, s);
+        println!(
+            "\n{:?}",
+            func.residual_vec(SVector::from([1.0, 2.0, 3.0, 4.0]))
+        );
+        let x = func.implicit_derivative_vec(SVector::from([1.0, 2.0, 3.0, 4.0]));
+        let x0 = ((s - 5.0).sqrt() - 5.0) * 0.5;
+        println!("{}, {}, {}, {}", x[0], x[1], x[2], x[3]);
+        println!("{}, {}, {}, {}", x0 + 1.0, x0 + 2.0, x0 + 3.0, x0 + 4.0);
+        assert_eq!(x0 + 1.0, x[0]);
+        assert_eq!(x0 + 2.0, x[1]);
+        assert_eq!(x0 + 3.0, x[2]);
+        assert_eq!(x0 + 4.0, x[3]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,8 @@ pub use dual2_vec::{
 };
 pub use dual3::{third_derivative, try_third_derivative, Dual3, Dual3_32, Dual3_64};
 pub use dual_vec::{
-    gradient, jacobian, try_gradient, try_jacobian, DualDVec32, DualDVec64, DualSVec32, DualSVec64,
-    DualVec, DualVec32, DualVec64,
+    gradient, jacobian, try_gradient, try_jacobian, DualDVec32, DualDVec64, DualSVec, DualSVec32,
+    DualSVec64, DualVec, DualVec32, DualVec64,
 };
 pub use hyperdual::{
     second_partial_derivative, try_second_partial_derivative, HyperDual, HyperDual32, HyperDual64,
@@ -87,7 +87,8 @@ pub use hyperhyperdual::{
     try_third_partial_derivative_vec, HyperHyperDual, HyperHyperDual32, HyperHyperDual64,
 };
 pub use implicit::{
-    implicit_derivative, implicit_derivative_binary, implicit_derivative_unary, Lift,
+    implicit_derivative, implicit_derivative_binary, implicit_derivative_vec, DualStruct,
+    ImplicitDerivative, ImplicitFunction,
 };
 
 #[cfg(feature = "linalg")]
@@ -113,7 +114,7 @@ pub trait DualNum<F>:
     + Product
     + FromPrimitive
     + From<F>
-    + Lift<Self, F>
+    + DualStruct<Self, F, Real = F>
     + fmt::Display
     + PartialEq
     + fmt::Debug

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -656,12 +656,17 @@ macro_rules! impl_num {
 #[macro_export]
 macro_rules! impl_lift {
     ($struct:ident$(, [$($dim:tt),*]$(, [$($ddim:tt),*])?)?) => {
-        impl<T: DualNum<F>, F: Float$($(, $dim: Dim)*)?> $crate::Lift<Self,F> for $struct<T, F$($(, $dim)*)?>
+        impl<T: DualNum<F>, F: Float$($(, $dim: Dim)*)?> $crate::DualStruct<Self,F> for $struct<T, F$($(, $dim)*)?>
         where
             $($(DefaultAllocator: Allocator<$dim> + Allocator<U1, $dim> + Allocator<$dim, $dim>,)*)?
             $($(DefaultAllocator: Allocator<$($ddim,)*>)?)?
         {
+            type Real = F;
             type Lifted<D2: DualNum<F, Inner = Self>> = D2;
+            #[inline]
+            fn real(&self) -> Self::Real {
+                self.re.real()
+            }
             #[inline]
             fn lift<D2: DualNum<F, Inner = Self>>(&self) -> Self::Lifted<D2> {
                 D2::from_inner(self.clone())


### PR DESCRIPTION
In addition to the `implicit_derivative` functions, this PR provides the `ImplicitFunction` trait, that can be used together with `ImplicitDerivative` in more general cases:
```rust
struct TestFunction2;
impl ImplicitFunction<f64> for TestFunction2 {
    type Parameters<D: DualNum<f64>> = (D, D);
    type Variable<D> = [D; 2];

    fn residual<D: DualNum<f64> + Copy>((square_sum, sum): &(D, D), [x, y]: [D; 2]) -> [D; 2] {
        [*square_sum - x * x - y * y, *sum - x - y]
    }
}
```
```rust
let a: crate::Dual64 = Dual::from(25.0).derivative();
let b: crate::Dual64 = Dual::from(7.0);
let func = ImplicitDerivative::new(TestFunction2, (a, b));
let res = func.residual_binary(4.0, 3.0));                // for interfacing nonlinear solvers
let [x, y] = func.implicit_derivative_binary(4.0, 3.0);   // to calculate the derivative afterwards
```