### PR TITLE
Custom implementations of `ComplexField::signum` that delegate to `Signed::signum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added custom implementations of `ComplexField::signum` for `Dual`, `Dual2`, `DualVec`, and `Dual2Vec`. These implementations delegate to `Signed::signum`, which sets the derivative part to `None` and avoids the floating point errors of the default implementation.
 
 ## [0.13.6] - 2026-03-08
 ### Fixed
@@ -57,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `pyo3` and `numpy` dependencies to 0.26.
 - Updated `criterion` dev-dependency to 0.7.
 - Updated Rust edition to 2024.
-- updated `nalgebra` dependency to 0.34. 
+- updated `nalgebra` dependency to 0.34.
 
 ## [0.11.2] - 2025-06-24
 ### Changed

--- a/src/datatypes/dual.rs
+++ b/src/datatypes/dual.rs
@@ -592,6 +592,11 @@ where
             None
         }
     }
+
+    #[inline]
+    fn signum(self) -> Self {
+        Signed::signum(&self)
+    }
 }
 
 impl<T> RealField for Dual<T, T::Element>

--- a/src/datatypes/dual2.rs
+++ b/src/datatypes/dual2.rs
@@ -641,6 +641,11 @@ where
             None
         }
     }
+
+    #[inline]
+    fn signum(self) -> Self {
+        Signed::signum(&self)
+    }
 }
 
 impl<T> RealField for Dual2<T, T::Element>

--- a/src/datatypes/dual2_vec.rs
+++ b/src/datatypes/dual2_vec.rs
@@ -712,6 +712,11 @@ where
             None
         }
     }
+
+    #[inline]
+    fn signum(self) -> Self {
+        Signed::signum(&self)
+    }
 }
 
 impl<T, D: Dim> RealField for Dual2Vec<T, T::Element, D>

--- a/src/datatypes/dual_vec.rs
+++ b/src/datatypes/dual_vec.rs
@@ -670,6 +670,11 @@ where
             None
         }
     }
+
+    #[inline]
+    fn signum(self) -> Self {
+        Signed::signum(&self)
+    }
 }
 
 impl<T, D: Dim> RealField for DualVec<T, T::Element, D>


### PR DESCRIPTION
Add custom implementations of `ComplexField::signum` for all types that implement the `ComplexField` trait: `Dual`, `Dual2`, `DualVec`, and `Dual2Vec`.

The custom implementation delegates to `Signed::signum`, which uses `Zero::zero` or `One::one` for the real part, and sets the derivatives to `None`. This prevents floating point errors encountered with the default `simba` implementation.