### PR TITLE
Update nalgebra 0.35, PyO3 and numpy 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Packaging
+- Updated `nalgebra` dependency to 0.35.
+- Updated `simba` dependency to 0.10.
+- Updated `pyo3` and `numpy` dependencies to 0.28.
+- Updated MSRV to 1.89.
+
 ## [0.13.7] - 2026-05-21
 ### Added
 - Added `DualNumCopy<F>` trait for dual numbers that have a static size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Packaging
 - Updated `nalgebra` dependency to 0.35.
 - Updated `simba` dependency to 0.10.
-- Updated `pyo3` and `numpy` dependencies to 0.28.
-- Updated MSRV to 1.89.
+- Updated `pyo3` and `numpy` dependencies to 0.28 and removed deprecated `extension-module` feature.
+- Updated `maturin` minimum required version to 1.9.4.
+- Updated minimum supported Rust version to 1.89.
 
 ## [0.13.7] - 2026-05-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Packaging
 - Updated `nalgebra` dependency to 0.35.
 - Updated `simba` dependency to 0.10.
-- Updated `pyo3` and `numpy` dependencies to 0.28 and removed deprecated `extension-module` feature.
+- Updated `pyo3` and `numpy` dependencies to 0.29 and removed deprecated `extension-module` feature.
 - Updated `maturin` minimum required version to 1.9.4.
 - Updated minimum supported Rust version to 1.89.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Specified `from_py_object` parameter for all `#[pyclass]` objects as this feature became opt-in rather than opt-out in `pyo3` 0.28.
+
 ### Packaging
 - Updated `nalgebra` dependency to 0.35.
 - Updated `simba` dependency to 0.10.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Gernot Bauer <bauer@itt.uni-stuttgart.de>",
     "Philipp Rehner <prehner@ethz.ch>",
 ]
-rust-version = "1.87"
+rust-version = "1.89"
 edition = "2024"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -21,15 +21,15 @@ name = "num_dual"
 
 [dependencies]
 num-traits = "0.2"
-nalgebra = "0.34"
-numpy = { version = "0.27", optional = true }
+nalgebra = "0.35"
+numpy = { version = "0.28", optional = true }
 approx = "0.5"
-simba = "0.9"
+simba = "0.10"
 serde = { version = "1.0", features = ["derive"], optional = true }
 ndarray = { version = "0.17", optional = true }
 
 [dependencies.pyo3]
-version = "0.27"
+version = "0.28"
 optional = true
 features = ["multiple-pymethods", "extension-module", "abi3", "abi3-py310"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ name = "num_dual"
 [dependencies]
 num-traits = "0.2"
 nalgebra = "0.35"
-numpy = { version = "0.28", optional = true }
+numpy = { version = "0.29", optional = true }
 approx = "0.5"
 simba = "0.10"
 serde = { version = "1.0", features = ["derive"], optional = true }
 ndarray = { version = "0.17", optional = true }
 
 [dependencies.pyo3]
-version = "0.28"
+version = "0.29"
 optional = true
 features = ["multiple-pymethods", "abi3", "abi3-py310"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ndarray = { version = "0.17", optional = true }
 [dependencies.pyo3]
 version = "0.28"
 optional = true
-features = ["multiple-pymethods", "extension-module", "abi3", "abi3-py310"]
+features = ["multiple-pymethods", "abi3", "abi3-py310"]
 
 [profile.release]
 lto = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/src/python/dual.rs
+++ b/src/python/dual.rs
@@ -4,7 +4,7 @@ use numpy::{PyArray, PyReadonlyArrayDyn, PyReadwriteArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Dual64")]
+#[pyclass(name = "Dual64", from_py_object)]
 #[derive(Clone, Debug)]
 /// Dual number using 64-bit-floats as fields.
 ///
@@ -48,7 +48,7 @@ impl_dual_num!(PyDual64, Dual64, f64);
 
 macro_rules! impl_dual_n {
     ($py_type_name:ident, $n:literal) => {
-        #[pyclass(name = "DualSVec64")]
+        #[pyclass(name = "DualSVec64", from_py_object)]
         #[derive(Clone, Copy)]
         pub struct $py_type_name(DualSVec64<$n>);
 
@@ -64,7 +64,7 @@ macro_rules! impl_dual_n {
     };
 }
 
-#[pyclass(name = "Dual64Dyn")]
+#[pyclass(name = "Dual64Dyn", from_py_object)]
 #[derive(Clone)]
 pub struct PyDual64Dyn(DualDVec64);
 

--- a/src/python/dual2.rs
+++ b/src/python/dual2.rs
@@ -5,7 +5,7 @@ use numpy::{PyArray, PyReadonlyArrayDyn, PyReadwriteArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Dual2_64")]
+#[pyclass(name = "Dual2_64", from_py_object)]
 #[derive(Clone)]
 /// Second order dual number using 64-bit-floats as fields.
 ///
@@ -55,7 +55,7 @@ impl PyDual2_64 {
 
 impl_dual_num!(PyDual2_64, Dual2_64, f64);
 
-#[pyclass(name = "Dual2Dual64")]
+#[pyclass(name = "Dual2Dual64", from_py_object)]
 #[derive(Clone)]
 /// Second order dual number using dual numbers as fields.
 pub struct PyDual2Dual64(Dual2<Dual64, f64>);
@@ -82,7 +82,7 @@ impl_dual_num!(PyDual2Dual64, Dual2<Dual64, f64>, PyDual64);
 
 macro_rules! impl_dual2_n {
     ($py_type_name:ident, $n:literal) => {
-        #[pyclass(name = "Dual2Vec64")]
+        #[pyclass(name = "Dual2Vec64", from_py_object)]
         #[derive(Clone, Copy)]
         pub struct $py_type_name(Dual2SVec64<$n>);
 
@@ -103,7 +103,7 @@ macro_rules! impl_dual2_n {
     };
 }
 
-#[pyclass(name = "Dual2_64Dyn")]
+#[pyclass(name = "Dual2_64Dyn", from_py_object)]
 #[derive(Clone)]
 pub struct PyDual2_64Dyn(Dual2DVec64);
 

--- a/src/python/dual3.rs
+++ b/src/python/dual3.rs
@@ -4,7 +4,7 @@ use numpy::{PyArray, PyReadonlyArrayDyn, PyReadwriteArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
-#[pyclass(name = "Dual3_64")]
+#[pyclass(name = "Dual3_64", from_py_object)]
 #[derive(Clone)]
 /// Third order dual number using 64-bit-floats as fields.
 pub struct PyDual3_64(Dual3_64);
@@ -34,7 +34,7 @@ impl PyDual3_64 {
 
 impl_dual_num!(PyDual3_64, Dual3_64, f64);
 
-#[pyclass(name = "Dual3Dual64")]
+#[pyclass(name = "Dual3Dual64", from_py_object)]
 #[derive(Clone)]
 /// Third order dual number using dual numbers as fields.
 pub struct PyDual3Dual64(Dual3<Dual64, f64>);

--- a/src/python/hyperdual.rs
+++ b/src/python/hyperdual.rs
@@ -5,7 +5,7 @@ use numpy::{PyArray, PyReadonlyArrayDyn, PyReadwriteArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
-#[pyclass(name = "HyperDual64")]
+#[pyclass(name = "HyperDual64", from_py_object)]
 #[derive(Clone)]
 /// Hyper-dual number using 64-bit-floats as fields.
 ///
@@ -54,7 +54,7 @@ impl PyHyperDual64 {
 
 impl_dual_num!(PyHyperDual64, HyperDual64, f64);
 
-#[pyclass(name = "HyperDualDual64")]
+#[pyclass(name = "HyperDualDual64", from_py_object)]
 #[derive(Clone)]
 /// Hyper-dual number using dual numbers as fields.
 pub struct PyHyperDualDual64(HyperDual<Dual64, f64>);
@@ -81,7 +81,7 @@ impl_dual_num!(PyHyperDualDual64, HyperDual<Dual64, f64>, PyDual64);
 
 macro_rules! impl_hyper_dual_mn {
     ($py_type_name:ident, $m:literal, $n:literal) => {
-        #[pyclass(name = "HyperDualVec64")]
+        #[pyclass(name = "HyperDualVec64", from_py_object)]
         #[derive(Clone, Copy)]
         pub struct $py_type_name(HyperDualSVec64<$m, $n>);
 
@@ -104,7 +104,7 @@ macro_rules! impl_hyper_dual_mn {
         impl_dual_num!($py_type_name, HyperDualSVec64<$m, $n>, f64);
     };
 }
-#[pyclass(name = "HyperDual64Dyn")]
+#[pyclass(name = "HyperDual64Dyn", from_py_object)]
 #[derive(Clone)]
 pub struct PyHyperDual64Dyn(HyperDualDVec64);
 

--- a/src/python/hyperhyperdual.rs
+++ b/src/python/hyperhyperdual.rs
@@ -3,7 +3,7 @@ use numpy::{PyArray, PyReadonlyArrayDyn, PyReadwriteArrayDyn};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 
-#[pyclass(name = "HyperHyperDual64")]
+#[pyclass(name = "HyperHyperDual64", from_py_object)]
 #[derive(Clone)]
 /// Third order hyper dual number using 64-bit-floats as fields.
 pub struct PyHyperHyperDual64(HyperHyperDual64);


### PR DESCRIPTION
- Updated `nalgebra` to 0.35, `simba` to 0.10, and PyO3 and `numpy` to 0.28.
- Updated MRSV to 1.89 to match the MSRV of `nalgebra` 0.35. See [upstream changelog](https://github.com/dimforge/nalgebra/blob/main/CHANGELOG.md)

Building the Python wheel with `maturin` generates several deprecation warnings:

```rust
warning: use of deprecated associated constant `pyo3::impl_::deprecated::HasAutomaticFromPyObject::<true>::MSG`: The `FromPyObject` implementation for `#[pyclass]` types which implement `Clone` is changing to an opt-in option. Use `#[pyclass(from_py_object)]` to opt-in to the `FromPyObject` derive now, or `#[pyclass(skip_from_py_object)]` to skip the `FromPyObject` implementation.
 --> src/python/dual.rs:7:1
  |
7 | #[pyclass(name = "Dual64")]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default
  = note: this warning originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
```

should I address them?